### PR TITLE
feat/retry record

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,6 @@ out
 
 *.tsbuildinfo
 
-logs/*
+logs
+
+docs/*.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,37 @@
+# Changelog
+
+## 2026-04-27
+
+### 中文
+
+- 支持部分页面生成失败后继续进入编辑页，已成功页面会被保留。
+- 失败页可以在详情页中直接用“当前页”编辑逻辑继续修复。
+- 新增生成记录，记录每次任务和每页成功/失败状态。
+- 统一使用系统设置中的模型配置，避免旧会话配置干扰生成。
+- 优化失败重试、进度恢复和本地模型 JSON 解析稳定性。
+
+### English
+
+- Added partial-failure recovery so completed pages can still be edited.
+- Failed pages can now be repaired from the detail page through the normal page-edit flow.
+- Added generation records for run-level and page-level status tracking.
+- Model settings now always come from system settings to avoid stale session config.
+- Improved retry handling, progress recovery, and JSON parsing for local models.
+
+## 2026-04-26
+
+### 中文
+
+- 支持本地 HTML 幻灯片生成、逐页预览和 PDF 导出。
+- 支持对话式单页编辑、元素检选和图片素材引用。
+- 内置多种风格 Skill，并提供风格管理页面。
+- 优化生成页动画、左侧缩略图、中间预览和右侧 AI 面板体验。
+- 补充 Ollama / OpenAI 兼容模型与未签名应用打开说明。
+
+### English
+
+- Added local HTML slide generation, page preview, and PDF export.
+- Added chat-based page editing, element inspection, and image asset references.
+- Added built-in style skills and a style management page.
+- Improved generation animation, thumbnails, preview canvas, and AI panel UX.
+- Added notes for Ollama / OpenAI-compatible models and unsigned app startup.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,37 +1,57 @@
-# Changelog
+# 更新日志 / Changelog
 
 ## 2026-04-27
 
 ### 中文
 
-- 支持部分页面生成失败后继续进入编辑页，已成功页面会被保留。
-- 失败页可以在详情页中直接用“当前页”编辑逻辑继续修复。
-- 新增生成记录，记录每次任务和每页成功/失败状态。
-- 统一使用系统设置中的模型配置，避免旧会话配置干扰生成。
-- 优化失败重试、进度恢复和本地模型 JSON 解析稳定性。
-
-### English
-
-- Added partial-failure recovery so completed pages can still be edited.
-- Failed pages can now be repaired from the detail page through the normal page-edit flow.
-- Added generation records for run-level and page-level status tracking.
-- Model settings now always come from system settings to avoid stale session config.
-- Improved retry handling, progress recovery, and JSON parsing for local models.
+- 新增版本提醒：应用启动后会检查 GitHub Releases，如有新版本会提示用户前往下载。
+- 优化生成恢复逻辑：应用意外或者退出后，可以根据已完成页面继续恢复进度。
+- 优化失败处理：全部失败时提示重新生成；部分完成时提示继续生成剩余页面。
+- 优化重试链路：只重试未完成页面，并保留用户补充说明。
+- 优化编辑稳定性：编辑时会校验页面结构，避免坏页面被误标记为完成。
+- 优化模型配置：生成与编辑统一使用系统设置中的最新模型配置。
+- 优化模型稳定性：增强大纲规划与 JSON 输出解析，减少弱模型或本地模型格式异常导致的失败。
 
 ## 2026-04-26
 
 ### 中文
 
-- 支持本地 HTML 幻灯片生成、逐页预览和 PDF 导出。
-- 支持对话式单页编辑、元素检选和图片素材引用。
-- 内置多种风格 Skill，并提供风格管理页面。
-- 优化生成页动画、左侧缩略图、中间预览和右侧 AI 面板体验。
-- 补充 Ollama / OpenAI 兼容模型与未签名应用打开说明。
+- 支持通过一句话生成本地 HTML 幻灯片。
+- 支持逐页预览、演示模式和键盘切换。
+- 支持对话式修改当前页内容。
+- 支持检选页面元素后精准修改。
+- 支持图片素材上传到本地会话目录并在编辑时引用。
+- 支持一键导出 PDF。
+- 新增风格管理，可查看、编辑和新增风格 Skill。
+- 优化生成页动画、缩略图列表、预览画布和右侧 AI 面板体验。
+- 补充 Ollama / OpenAI 兼容模型使用说明。
+- 补充 macOS 与 Windows 未签名应用打开说明。
+
+---
+
+## 2026-04-27
 
 ### English
 
-- Added local HTML slide generation, page preview, and PDF export.
-- Added chat-based page editing, element inspection, and image asset references.
-- Added built-in style skills and a style management page.
-- Improved generation animation, thumbnails, preview canvas, and AI panel UX.
-- Added notes for Ollama / OpenAI-compatible models and unsigned app startup.
+- Added update notifications: the app checks GitHub Releases on startup and lets users open the release page when a newer version is available.
+- Improved generation recovery: progress can be restored from completed pages after an unexpected app exit.
+- Improved failure handling: fully failed sessions prompt regeneration, while partially completed sessions can continue remaining pages.
+- Improved retry flow: only unfinished pages are retried, and user retry notes are preserved.
+- Improved edit stability: page structure is validated before marking edits as completed.
+- Unified model settings: generation and editing now always use the latest model configuration from Settings.
+- Improved model stability: outline planning and JSON output parsing are more tolerant of malformed local/weak-model responses.
+
+## 2026-04-26
+
+### English
+
+- Added one-prompt local HTML slide generation.
+- Added page-by-page preview, presentation mode, and keyboard navigation.
+- Added chat-based editing for the current page.
+- Added element inspection for more precise edits.
+- Added local image asset uploads for use during page editing.
+- Added one-click PDF export.
+- Added style management for viewing, editing, and creating style skills.
+- Improved the generation animation, thumbnail list, preview canvas, and AI message panel.
+- Added usage notes for Ollama / OpenAI-compatible models.
+- Added notes for opening unsigned macOS and Windows builds.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 **Oh My PPT - 纯本地 AI 幻灯片生成与编辑工具**
 
-[English](./README_EN.md) | [为什么做这个](#why) • [能做什么](#features) • [使用流程](#workflow) • [使用问题](#usage-notes)
+[English](./README_EN.md) | [为什么做这个](#why) • [能做什么](#features) • [使用流程](#workflow) • [更新日志](./CHANGELOG.md) • [使用问题](#usage-notes)
 
   <p>
     Local-first AI Slide Deck Generator<br/>
@@ -22,7 +22,7 @@
 
   <img src="https://arcsin1.github.io/ohmyppt.gif" alt="Oh My PPT" width="600" />
 
-  [观看完整演示视频](https://arcsin1.github.io/ohmyppt.mp4) | [下载安装包（v0.0.2）](https://github.com/arcsin1/oh-my-ppt/releases)
+  [观看完整演示视频](https://arcsin1.github.io/ohmyppt.mp4) | [下载安装包](https://github.com/arcsin1/oh-my-ppt/releases)
 </div>
 
 ---

--- a/README_EN.md
+++ b/README_EN.md
@@ -12,7 +12,7 @@
 
 **Oh My PPT - Local-first AI Slide Deck Generator & Editor**
 
-[中文](./README.md) | [Why](#why) • [Features](#features) • [Workflow](#workflow) • [Reference](#reference) • [Usage Notes](#usage-notes)
+[中文](./README.md) | [Why](#why) • [Features](#features) • [Workflow](#workflow) • [Changelog](./CHANGELOG.md) • [Reference](#reference) • [Usage Notes](#usage-notes)
 
   <p>
     Local-first AI Slide Deck Generator<br/>
@@ -22,7 +22,7 @@
 
   <img src="https://arcsin1.github.io/ohmyppt.gif" alt="Oh My PPT" width="600" />
 
-  [Watch demo video](https://arcsin1.github.io/ohmyppt.mp4) | [Download release package (v0.0.2)](https://github.com/arcsin1/oh-my-ppt/releases/)
+  [Watch demo video](https://arcsin1.github.io/ohmyppt.mp4) | [Download release package](https://github.com/arcsin1/oh-my-ppt/releases/)
 </div>
 
 ---

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-ppt",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Oh My PPT - Local-first AI presentation workbench",
   "main": "./out/main/index.js",
   "author": "arcsin1",

--- a/src/main/agent.ts
+++ b/src/main/agent.ts
@@ -33,6 +33,7 @@ interface AgentSessionEntry {
   provider: string;
   model: string;
   baseUrl?: string;
+  temperature?: number;
 }
 
 // ── Agent factory ──
@@ -40,12 +41,13 @@ interface AgentSessionEntry {
 export function createSessionEditAgent(args: {
   provider: string;
   apiKey: string;
-  model?: string;
+  model: string;
   baseUrl?: string;
+  temperature?: number;
   styleId?: string | null;
   context: SessionDeckGenerationContext;
 }): DeepAgentStreamResult {
-  const model = resolveModel(args.provider, args.apiKey, args.model, args.baseUrl);
+  const model = resolveModel(args.provider, args.apiKey, args.model, args.baseUrl, args.temperature);
   const backend = new FilesystemBackend({
     rootDir: args.context.projectDir,
     virtualMode: true,
@@ -56,7 +58,7 @@ export function createSessionEditAgent(args: {
   log.info("[deepagent] create session edit agent", {
     sessionId: args.context.sessionId,
     provider: args.provider,
-    model: args.model || "",
+    model: args.model,
     styleId: args.styleId || "",
     projectDir: args.context.projectDir,
     indexPath: args.context.indexPath,
@@ -74,12 +76,13 @@ export function createSessionEditAgent(args: {
 export function createSessionDeckAgent(args: {
   provider: string;
   apiKey: string;
-  model?: string;
+  model: string;
   baseUrl?: string;
+  temperature?: number;
   styleId?: string | null;
   context: SessionDeckGenerationContext;
 }): DeepAgentStreamResult {
-  const model = resolveModel(args.provider, args.apiKey, args.model, args.baseUrl);
+  const model = resolveModel(args.provider, args.apiKey, args.model, args.baseUrl, args.temperature);
   const backend = new FilesystemBackend({
     rootDir: args.context.projectDir,
     virtualMode: true,
@@ -96,7 +99,7 @@ export function createSessionDeckAgent(args: {
   log.info("[deepagent] create session deck agent", {
     sessionId: args.context.sessionId,
     provider: args.provider,
-    model: args.model || "",
+    model: args.model,
     styleId: args.styleId || "",
     projectDir: args.context.projectDir,
     indexPath: args.context.indexPath,
@@ -119,40 +122,45 @@ export function createSessionDeckAgent(args: {
 
 // ── Model resolution ──
 
-const MODEL_DEFAULTS: Record<string, string> = {
-  openai: "gpt-4o",
-  anthropic: "claude-sonnet-4-5-20250929",
-  deepseek: "deepseek-chat",
-};
+export const DEFAULT_MODEL_TEMPERATURE = 0.7;
 
 export function resolveModel(
   provider: string,
   apiKey: string,
-  model?: string,
-  baseUrl?: string
+  model: string,
+  baseUrl?: string,
+  temperature?: number
 ): BaseLanguageModel {
-  const resolvedModel = model || MODEL_DEFAULTS[provider] || MODEL_DEFAULTS.anthropic;
+  const resolvedModel = model.trim();
+  if (!resolvedModel) {
+    throw new Error("model 不能为空，请先在系统设置中配置模型。");
+  }
+  const resolvedTemperature =
+    Number.isFinite(temperature) && typeof temperature === "number"
+      ? Math.max(0, Math.min(2, temperature))
+      : DEFAULT_MODEL_TEMPERATURE;
 
-  log.info("[llm] resolveModel", { provider, model: resolvedModel, baseUrl: baseUrl || "" });
+  log.info("[llm] resolveModel", {
+    provider,
+    model: resolvedModel,
+    baseUrl: baseUrl || "",
+    temperature: resolvedTemperature ?? null,
+  });
 
   switch (provider) {
     case "openai":
       return new ChatOpenAI({
         model: resolvedModel,
         apiKey,
+        temperature: resolvedTemperature,
         configuration: baseUrl ? { baseURL: baseUrl } : undefined,
       });
     case "anthropic":
       return new ChatAnthropic({
         model: resolvedModel,
         apiKey,
+        temperature: resolvedTemperature,
         anthropicApiUrl: baseUrl || undefined,
-      });
-    case "deepseek":
-      return new ChatOpenAI({
-        model: resolvedModel,
-        apiKey,
-        configuration: { baseURL: baseUrl || "https://api.deepseek.com/v1" },
       });
     default:
       throw new Error(`Unknown provider: ${provider}`);
@@ -164,14 +172,11 @@ export function resolveModel(
 export interface AgentSessionConfig {
   sessionId: string;
   provider: string;
-  apiKey: string;
-  model?: string;
+  model: string;
   baseUrl?: string;
+  temperature?: number;
   projectDir: string;
-  db: PPTDatabase;
 }
-
-const DEFAULT_MODEL = "claude-sonnet-4-5-20250929";
 
 export class AgentManager {
   private agents = new Map<string, AgentSessionEntry>();
@@ -185,7 +190,10 @@ export class AgentManager {
       pageCount?: number
     }
   ): Promise<string> {
-    const model = config.model || DEFAULT_MODEL;
+    const model = config.model.trim();
+    if (!model) {
+      throw new Error("创建会话失败：model 不能为空。");
+    }
     log.info("[agent] createSession", {
       sessionId: config.sessionId,
       provider: config.provider,
@@ -214,6 +222,7 @@ export class AgentManager {
       provider: config.provider,
       model,
       baseUrl: config.baseUrl,
+      temperature: config.temperature,
     });
 
     return sessionId;
@@ -251,22 +260,33 @@ export class AgentManager {
   ensureSession(config: {
     sessionId: string
     provider: string
-    model?: string
+    model: string
     baseUrl?: string
+    temperature?: number
     projectDir: string
   }) {
     const existing = this.agents.get(config.sessionId);
     if (existing) {
+      existing.provider = config.provider;
+      existing.model = config.model;
+      existing.baseUrl = config.baseUrl;
+      existing.temperature = config.temperature;
+      existing.projectDir = config.projectDir;
       log.info("[agent] ensureSession hit existing", {
         sessionId: config.sessionId,
         provider: existing.provider,
         model: existing.model,
+        baseUrl: existing.baseUrl || "",
+        temperature: existing.temperature ?? null,
         projectDir: existing.projectDir,
       });
       return existing;
     }
 
-    const model = config.model || DEFAULT_MODEL;
+    const model = config.model.trim();
+    if (!model) {
+      throw new Error("恢复会话失败：model 不能为空。");
+    }
     const entry = {
       agent: null,
       pageAgents: new Map<string, DeepAgentStreamResult>(),
@@ -275,6 +295,7 @@ export class AgentManager {
       provider: config.provider,
       model,
       baseUrl: config.baseUrl,
+      temperature: config.temperature,
     };
 
     log.info("[agent] ensureSession create entry", {
@@ -282,6 +303,7 @@ export class AgentManager {
       provider: entry.provider,
       model,
       baseUrl: entry.baseUrl || "",
+      temperature: entry.temperature ?? null,
       projectDir: entry.projectDir,
     });
 

--- a/src/main/db/database.ts
+++ b/src/main/db/database.ts
@@ -7,12 +7,16 @@ import { app } from "electron";
 import { is } from "@electron-toolkit/utils";
 import fs from "fs";
 import crypto from "crypto";
+import { runDatabasePatches } from "./patch";
 
 type SessionStatus = "active" | "completed" | "failed" | "archived";
 type MessageRole = "user" | "assistant" | "system" | "tool";
 type MessageType = "text" | "tool_call" | "tool_result" | "stream_chunk";
 type ChatScope = "main" | "page";
 type StyleSource = "builtin" | "custom" | "override";
+type GenerationRunMode = "generate" | "retry" | "edit";
+type GenerationRunStatus = "running" | "completed" | "failed" | "partial";
+type GenerationPageStatus = "pending" | "running" | "completed" | "failed";
 
 export interface Session {
   id: string;
@@ -76,6 +80,34 @@ interface Project {
   updated_at: number;
 }
 
+export interface GenerationRunRecord {
+  id: string;
+  session_id: string;
+  mode: GenerationRunMode;
+  status: GenerationRunStatus;
+  total_pages: number;
+  error: string | null;
+  metadata: string | null;
+  created_at: number;
+  updated_at: number;
+}
+
+export interface GenerationPageRecord {
+  id: string;
+  run_id: string;
+  session_id: string;
+  page_id: string;
+  page_number: number;
+  title: string;
+  content_outline: string | null;
+  html_path: string | null;
+  status: GenerationPageStatus;
+  error: string | null;
+  retry_count: number;
+  created_at: number;
+  updated_at: number;
+}
+
 export interface StyleRow {
   id: string;
   style: string;
@@ -88,108 +120,6 @@ export interface StyleRow {
   createdAt: number;
   updatedAt: number;
 }
-
-const SETTINGS_TABLE_SQL = `
-CREATE TABLE IF NOT EXISTS settings (
-  key TEXT PRIMARY KEY,
-  value TEXT NOT NULL,
-  updated_at INTEGER NOT NULL
-);
-`;
-
-const MESSAGES_TABLE_SQL = `
-CREATE TABLE IF NOT EXISTS messages (
-  id TEXT PRIMARY KEY,
-  session_id TEXT NOT NULL,
-  chat_scope TEXT NOT NULL DEFAULT 'main',
-  page_id TEXT,
-  selector TEXT,
-  image_paths TEXT,
-  role TEXT NOT NULL,
-  content TEXT NOT NULL,
-  type TEXT,
-  tool_name TEXT,
-  tool_call_id TEXT,
-  token_count INTEGER,
-  created_at INTEGER NOT NULL
-);
-
-CREATE INDEX IF NOT EXISTS idx_messages_session ON messages(session_id, created_at);
-CREATE INDEX IF NOT EXISTS idx_messages_session_scope ON messages(session_id, chat_scope, page_id, created_at);
-CREATE INDEX IF NOT EXISTS idx_messages_session_only ON messages(session_id);
-`;
-
-const INIT_SQL = `
-CREATE TABLE IF NOT EXISTS sessions (
-  id TEXT PRIMARY KEY,
-  title TEXT NOT NULL,
-  topic TEXT,
-  style_id TEXT,
-  page_count INTEGER,
-  status TEXT NOT NULL DEFAULT 'active',
-  provider TEXT NOT NULL,
-  model TEXT NOT NULL,
-  created_at INTEGER NOT NULL,
-  updated_at INTEGER NOT NULL,
-  metadata TEXT,
-  design_contract TEXT
-);
-
-${MESSAGES_TABLE_SQL}
-
-CREATE TABLE IF NOT EXISTS projects (
-  id TEXT PRIMARY KEY,
-  session_id TEXT NOT NULL,
-  title TEXT NOT NULL,
-  output_path TEXT NOT NULL,
-  file_count INTEGER DEFAULT 0,
-  total_size INTEGER DEFAULT 0,
-  status TEXT NOT NULL DEFAULT 'draft',
-  created_at INTEGER NOT NULL,
-  updated_at INTEGER NOT NULL
-);
-
-${SETTINGS_TABLE_SQL}
-
-CREATE TABLE IF NOT EXISTS memory_summaries (
-  id TEXT PRIMARY KEY,
-  session_id TEXT NOT NULL,
-  message_range_start INTEGER NOT NULL,
-  message_range_end INTEGER NOT NULL,
-  summary TEXT NOT NULL,
-  token_count INTEGER,
-  created_at INTEGER NOT NULL
-);
-
-CREATE INDEX IF NOT EXISTS idx_memory_summaries_session ON memory_summaries(session_id, message_range_end);
-
-CREATE INDEX IF NOT EXISTS idx_projects_session ON projects(session_id);
-CREATE INDEX IF NOT EXISTS idx_memory_summaries_session_id ON memory_summaries(session_id);
-
-CREATE TABLE IF NOT EXISTS user_preferences (
-  key TEXT PRIMARY KEY,
-  value TEXT NOT NULL,
-  confidence REAL DEFAULT 1.0,
-  source_sessions TEXT,
-  created_at INTEGER NOT NULL,
-  updated_at INTEGER NOT NULL,
-  last_used_at INTEGER
-);
-
-CREATE TABLE IF NOT EXISTS styles (
-  id TEXT PRIMARY KEY,
-  style TEXT UNIQUE NOT NULL,
-  style_name TEXT NOT NULL,
-  description TEXT NOT NULL DEFAULT '',
-  category TEXT NOT NULL DEFAULT '',
-  aliases TEXT NOT NULL DEFAULT '[]',
-  source TEXT NOT NULL DEFAULT 'custom',
-  style_skill TEXT NOT NULL DEFAULT '',
-  created_at INTEGER NOT NULL,
-  updated_at INTEGER NOT NULL
-);
-CREATE UNIQUE INDEX IF NOT EXISTS idx_styles_style ON styles(style);
-`;
 
 export class PPTDatabase {
   private db: ReturnType<typeof drizzle>;
@@ -218,102 +148,13 @@ export class PPTDatabase {
 
   async init(): Promise<void> {
     if (this._initialized) return;
-    await this.client.executeMultiple(INIT_SQL);
-    await this._enforceSessionsSchema();
-    await this._enforceSettingsSchema();
-    await this._enforceMessagesSchema();
-    await this.client.execute("PRAGMA foreign_keys = ON;");
-    await this._ensureDefaultSettings();
+    await runDatabasePatches({
+      client: this.client,
+      db: this.db,
+      resolveStoragePath: async () => (await this.getSetting<string>("storage_path").catch(() => "")) || "",
+    });
     await this.seedStylesFromResources();
     this._initialized = true;
-  }
-
-  private async _getTableColumns(tableName: "settings" | "messages" | "sessions"): Promise<Set<string>> {
-    const result = await this.client.execute(`PRAGMA table_info(${tableName})`);
-    const rows = Array.isArray((result as { rows?: unknown[] }).rows)
-      ? ((result as { rows?: unknown[] }).rows as unknown[])
-      : [];
-    const columns = new Set<string>();
-    for (const row of rows) {
-      if (row && typeof row === "object" && "name" in row) {
-        const name = (row as { name?: unknown }).name;
-        if (typeof name === "string" && name.trim().length > 0) {
-          columns.add(name.trim());
-        }
-        continue;
-      }
-      if (Array.isArray(row) && typeof row[1] === "string" && row[1].trim().length > 0) {
-        columns.add(row[1].trim());
-      }
-    }
-    return columns;
-  }
-
-  private async _enforceSettingsSchema(): Promise<void> {
-    await this.client.execute(SETTINGS_TABLE_SQL);
-    const columns = await this._getTableColumns("settings");
-    if (!columns.has("value")) {
-      await this.client.execute(`ALTER TABLE settings ADD COLUMN value TEXT NOT NULL DEFAULT '""'`);
-    }
-    if (!columns.has("updated_at")) {
-      await this.client.execute("ALTER TABLE settings ADD COLUMN updated_at INTEGER NOT NULL DEFAULT 0");
-    }
-    await this.client.execute("CREATE UNIQUE INDEX IF NOT EXISTS idx_settings_key ON settings(key)");
-  }
-
-  private async _enforceSessionsSchema(): Promise<void> {
-    const columns = await this._getTableColumns("sessions");
-    if (!columns.has("style_id")) {
-      await this.client.execute("ALTER TABLE sessions ADD COLUMN style_id TEXT");
-    }
-  }
-
-  private async _enforceMessagesSchema(): Promise<void> {
-    await this.client.executeMultiple(MESSAGES_TABLE_SQL);
-    const columns = await this._getTableColumns("messages");
-    if (!columns.has("chat_scope")) {
-      await this.client.execute(`ALTER TABLE messages ADD COLUMN chat_scope TEXT NOT NULL DEFAULT 'main'`);
-    }
-    if (!columns.has("page_id")) {
-      await this.client.execute("ALTER TABLE messages ADD COLUMN page_id TEXT");
-    }
-    if (!columns.has("selector")) {
-      await this.client.execute("ALTER TABLE messages ADD COLUMN selector TEXT");
-    }
-    if (!columns.has("image_paths")) {
-      await this.client.execute("ALTER TABLE messages ADD COLUMN image_paths TEXT");
-    }
-    if (!columns.has("type")) {
-      await this.client.execute("ALTER TABLE messages ADD COLUMN type TEXT");
-    }
-    if (!columns.has("tool_name")) {
-      await this.client.execute("ALTER TABLE messages ADD COLUMN tool_name TEXT");
-    }
-    if (!columns.has("tool_call_id")) {
-      await this.client.execute("ALTER TABLE messages ADD COLUMN tool_call_id TEXT");
-    }
-    if (!columns.has("token_count")) {
-      await this.client.execute("ALTER TABLE messages ADD COLUMN token_count INTEGER");
-    }
-    await this.client.execute("CREATE INDEX IF NOT EXISTS idx_messages_session ON messages(session_id, created_at)");
-    await this.client.execute("CREATE INDEX IF NOT EXISTS idx_messages_session_scope ON messages(session_id, chat_scope, page_id, created_at)");
-    await this.client.execute("CREATE INDEX IF NOT EXISTS idx_messages_session_only ON messages(session_id)");
-  }
-
-  private async _ensureDefaultSettings(): Promise<void> {
-    const now = Math.floor(Date.now() / 1000);
-    const defaults = [
-      { key: "provider", value: '"openai"' },
-      { key: "theme", value: '"light"' },
-      { key: "auto_save", value: "true" },
-    ];
-
-    for (const { key, value } of defaults) {
-      await this.client.execute({
-        sql: "INSERT OR IGNORE INTO settings (key, value, updated_at) VALUES (?, ?, ?)",
-        args: [key, value, now],
-      });
-    }
   }
 
   getStoragePath(): string {
@@ -404,7 +245,176 @@ export class PPTDatabase {
   }
 
   async deleteSession(sessionId: string): Promise<void> {
+    await this.db.delete(schema.generationPages).where(eq(schema.generationPages.sessionId, sessionId)).run();
+    await this.db.delete(schema.generationRuns).where(eq(schema.generationRuns.sessionId, sessionId)).run();
     await this.db.delete(schema.sessions).where(eq(schema.sessions.id, sessionId)).run();
+  }
+
+  // ========== Generation Records ==========
+
+  private normalizeGenerationRunRow(row: Record<string, unknown>): GenerationRunRecord {
+    return {
+      id: String(row.id || ""),
+      session_id: String(row.sessionId ?? row.session_id ?? ""),
+      mode: String(row.mode || "generate") as GenerationRunMode,
+      status: String(row.status || "running") as GenerationRunStatus,
+      total_pages: Number(row.totalPages ?? row.total_pages ?? 0) || 0,
+      error: typeof (row.error) === "string" ? String(row.error) : null,
+      metadata: typeof (row.metadata) === "string" ? String(row.metadata) : null,
+      created_at: Number(row.createdAt ?? row.created_at ?? 0) || 0,
+      updated_at: Number(row.updatedAt ?? row.updated_at ?? 0) || 0,
+    };
+  }
+
+  private normalizeGenerationPageRow(row: Record<string, unknown>): GenerationPageRecord {
+    return {
+      id: String(row.id || ""),
+      run_id: String(row.runId ?? row.run_id ?? ""),
+      session_id: String(row.sessionId ?? row.session_id ?? ""),
+      page_id: String(row.pageId ?? row.page_id ?? ""),
+      page_number: Number(row.pageNumber ?? row.page_number ?? 0) || 0,
+      title: String(row.title || ""),
+      content_outline:
+        typeof (row.contentOutline ?? row.content_outline) === "string"
+          ? String(row.contentOutline ?? row.content_outline)
+          : null,
+      html_path:
+        typeof (row.htmlPath ?? row.html_path) === "string"
+          ? String(row.htmlPath ?? row.html_path)
+          : null,
+      status: String(row.status || "pending") as GenerationPageStatus,
+      error: typeof row.error === "string" ? String(row.error) : null,
+      retry_count: Number(row.retryCount ?? row.retry_count ?? 0) || 0,
+      created_at: Number(row.createdAt ?? row.created_at ?? 0) || 0,
+      updated_at: Number(row.updatedAt ?? row.updated_at ?? 0) || 0,
+    };
+  }
+
+  async createGenerationRun(data: {
+    id?: string;
+    sessionId: string;
+    mode: GenerationRunMode;
+    totalPages: number;
+    metadata?: unknown;
+  }): Promise<string> {
+    const id = data.id || crypto.randomUUID();
+    const now = Math.floor(Date.now() / 1000);
+    await this.db.insert(schema.generationRuns).values({
+      id,
+      sessionId: data.sessionId,
+      mode: data.mode,
+      status: "running",
+      totalPages: Math.max(0, Math.floor(data.totalPages || 0)),
+      error: null,
+      metadata: data.metadata ? JSON.stringify(data.metadata) : null,
+      createdAt: now,
+      updatedAt: now,
+    }).run();
+    return id;
+  }
+
+  async updateGenerationRunStatus(runId: string, status: GenerationRunStatus, error?: string | null): Promise<void> {
+    await this.db.update(schema.generationRuns).set({
+      status,
+      error: error || null,
+      updatedAt: Math.floor(Date.now() / 1000),
+    }).where(eq(schema.generationRuns.id, runId)).run();
+  }
+
+  async getGenerationRun(runId: string): Promise<GenerationRunRecord | undefined> {
+    const row = await this.db
+      .select()
+      .from(schema.generationRuns)
+      .where(eq(schema.generationRuns.id, runId))
+      .get();
+    return row ? this.normalizeGenerationRunRow(row as Record<string, unknown>) : undefined;
+  }
+
+  async getLatestGenerationRun(sessionId: string): Promise<GenerationRunRecord | undefined> {
+    const row = await this.db
+      .select()
+      .from(schema.generationRuns)
+      .where(eq(schema.generationRuns.sessionId, sessionId))
+      .orderBy(desc(schema.generationRuns.createdAt))
+      .limit(1)
+      .get();
+    return row ? this.normalizeGenerationRunRow(row as Record<string, unknown>) : undefined;
+  }
+
+  async upsertGenerationPage(data: {
+    runId: string;
+    sessionId: string;
+    pageId: string;
+    pageNumber: number;
+    title: string;
+    contentOutline?: string | null;
+    htmlPath?: string | null;
+    status: GenerationPageStatus;
+    error?: string | null;
+    retryCount?: number;
+  }): Promise<void> {
+    const now = Math.floor(Date.now() / 1000);
+    const id = `${data.runId}:${data.pageId}`;
+    const values = {
+      id,
+      runId: data.runId,
+      sessionId: data.sessionId,
+      pageId: data.pageId,
+      pageNumber: data.pageNumber,
+      title: data.title,
+      contentOutline: data.contentOutline || null,
+      htmlPath: data.htmlPath || null,
+      status: data.status,
+      error: data.error || null,
+      retryCount: Math.max(0, Math.floor(data.retryCount || 0)),
+      createdAt: now,
+      updatedAt: now,
+    };
+    await this.db.insert(schema.generationPages).values(values).onConflictDoUpdate({
+      target: schema.generationPages.id,
+      set: {
+        pageNumber: values.pageNumber,
+        title: values.title,
+        contentOutline: values.contentOutline,
+        htmlPath: values.htmlPath,
+        status: values.status,
+        error: values.error,
+        retryCount: values.retryCount,
+        updatedAt: now,
+      },
+    }).run();
+  }
+
+  async listGenerationPages(runId: string): Promise<GenerationPageRecord[]> {
+    const rows = await this.db
+      .select()
+      .from(schema.generationPages)
+      .where(eq(schema.generationPages.runId, runId))
+      .orderBy(asc(schema.generationPages.pageNumber))
+      .all();
+    return rows.map((row) => this.normalizeGenerationPageRow(row as Record<string, unknown>));
+  }
+
+  async listLatestFailedGenerationPages(sessionId: string): Promise<GenerationPageRecord[]> {
+    const run = await this.getLatestGenerationRun(sessionId);
+    if (!run) return [];
+    return (await this.listGenerationPages(run.id)).filter((page) => page.status === "failed");
+  }
+
+  async listLatestGenerationPageSnapshot(sessionId: string): Promise<GenerationPageRecord[]> {
+    const rows = await this.db
+      .select()
+      .from(schema.generationPages)
+      .where(eq(schema.generationPages.sessionId, sessionId))
+      .orderBy(asc(schema.generationPages.pageNumber), desc(schema.generationPages.updatedAt))
+      .all();
+    const latestByPageId = new Map<string, GenerationPageRecord>();
+    for (const row of rows) {
+      const page = this.normalizeGenerationPageRow(row as Record<string, unknown>);
+      if (!page.page_id || latestByPageId.has(page.page_id)) continue;
+      latestByPageId.set(page.page_id, page);
+    }
+    return Array.from(latestByPageId.values()).sort((a, b) => a.page_number - b.page_number);
   }
 
   // ========== Messages ==========

--- a/src/main/db/patch/index.ts
+++ b/src/main/db/patch/index.ts
@@ -1,0 +1,492 @@
+import type { createClient } from "@libsql/client";
+import type { drizzle } from "drizzle-orm/libsql";
+import path from "path";
+import * as schema from "../schema";
+import type { GenerationPageStatus, GenerationRunStatus } from "../schema";
+
+type LibSqlClient = ReturnType<typeof createClient>;
+type DrizzleDb = ReturnType<typeof drizzle>;
+
+const SETTINGS_TABLE_SQL = `
+CREATE TABLE IF NOT EXISTS settings (
+  key TEXT PRIMARY KEY,
+  value TEXT NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+`;
+
+const MESSAGES_TABLE_SQL = `
+CREATE TABLE IF NOT EXISTS messages (
+  id TEXT PRIMARY KEY,
+  session_id TEXT NOT NULL,
+  chat_scope TEXT NOT NULL DEFAULT 'main',
+  page_id TEXT,
+  selector TEXT,
+  image_paths TEXT,
+  role TEXT NOT NULL,
+  content TEXT NOT NULL,
+  type TEXT,
+  tool_name TEXT,
+  tool_call_id TEXT,
+  token_count INTEGER,
+  created_at INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_messages_session ON messages(session_id, created_at);
+CREATE INDEX IF NOT EXISTS idx_messages_session_scope ON messages(session_id, chat_scope, page_id, created_at);
+CREATE INDEX IF NOT EXISTS idx_messages_session_only ON messages(session_id);
+`;
+
+const INIT_SQL = `
+CREATE TABLE IF NOT EXISTS sessions (
+  id TEXT PRIMARY KEY,
+  title TEXT NOT NULL,
+  topic TEXT,
+  style_id TEXT,
+  page_count INTEGER,
+  status TEXT NOT NULL DEFAULT 'active',
+  provider TEXT NOT NULL,
+  model TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  metadata TEXT,
+  design_contract TEXT
+);
+
+${MESSAGES_TABLE_SQL}
+
+CREATE TABLE IF NOT EXISTS projects (
+  id TEXT PRIMARY KEY,
+  session_id TEXT NOT NULL,
+  title TEXT NOT NULL,
+  output_path TEXT NOT NULL,
+  file_count INTEGER DEFAULT 0,
+  total_size INTEGER DEFAULT 0,
+  status TEXT NOT NULL DEFAULT 'draft',
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+
+${SETTINGS_TABLE_SQL}
+
+CREATE TABLE IF NOT EXISTS memory_summaries (
+  id TEXT PRIMARY KEY,
+  session_id TEXT NOT NULL,
+  message_range_start INTEGER NOT NULL,
+  message_range_end INTEGER NOT NULL,
+  summary TEXT NOT NULL,
+  token_count INTEGER,
+  created_at INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_memory_summaries_session ON memory_summaries(session_id, message_range_end);
+
+CREATE INDEX IF NOT EXISTS idx_projects_session ON projects(session_id);
+CREATE INDEX IF NOT EXISTS idx_memory_summaries_session_id ON memory_summaries(session_id);
+
+CREATE TABLE IF NOT EXISTS generation_runs (
+  id TEXT PRIMARY KEY,
+  session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+  mode TEXT NOT NULL DEFAULT 'generate',
+  status TEXT NOT NULL DEFAULT 'running',
+  total_pages INTEGER NOT NULL DEFAULT 0,
+  error TEXT,
+  metadata TEXT,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_generation_runs_session ON generation_runs(session_id, created_at);
+
+CREATE TABLE IF NOT EXISTS generation_pages (
+  id TEXT PRIMARY KEY,
+  run_id TEXT NOT NULL REFERENCES generation_runs(id) ON DELETE CASCADE,
+  session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+  page_id TEXT NOT NULL,
+  page_number INTEGER NOT NULL,
+  title TEXT NOT NULL,
+  content_outline TEXT,
+  html_path TEXT,
+  status TEXT NOT NULL DEFAULT 'pending',
+  error TEXT,
+  retry_count INTEGER NOT NULL DEFAULT 0,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_generation_pages_run ON generation_pages(run_id, page_number);
+CREATE INDEX IF NOT EXISTS idx_generation_pages_session_status ON generation_pages(session_id, status, page_number);
+
+CREATE TABLE IF NOT EXISTS user_preferences (
+  key TEXT PRIMARY KEY,
+  value TEXT NOT NULL,
+  confidence REAL DEFAULT 1.0,
+  source_sessions TEXT,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  last_used_at INTEGER
+);
+
+CREATE TABLE IF NOT EXISTS styles (
+  id TEXT PRIMARY KEY,
+  style TEXT UNIQUE NOT NULL,
+  style_name TEXT NOT NULL,
+  description TEXT NOT NULL DEFAULT '',
+  category TEXT NOT NULL DEFAULT '',
+  aliases TEXT NOT NULL DEFAULT '[]',
+  source TEXT NOT NULL DEFAULT 'custom',
+  style_skill TEXT NOT NULL DEFAULT '',
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_styles_style ON styles(style);
+`;
+
+const getRowValue = (row: unknown, key: string): unknown => {
+  if (row && typeof row === "object" && !Array.isArray(row) && key in row) {
+    return (row as Record<string, unknown>)[key];
+  }
+  return undefined;
+};
+
+const parseJsonObject = (value: unknown): Record<string, unknown> => {
+  if (typeof value !== "string" || value.trim().length === 0) return {};
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? parsed as Record<string, unknown>
+      : {};
+  } catch {
+    return {};
+  }
+};
+
+const toPositiveInt = (value: unknown, fallback: number): number => {
+  const number = Number(value);
+  return Number.isFinite(number) && number > 0 ? Math.floor(number) : fallback;
+};
+
+const inferPageNumber = (page: Record<string, unknown>, fallback: number): number => {
+  const explicit = toPositiveInt(page.pageNumber ?? page.page_number, 0);
+  if (explicit > 0) return explicit;
+  const rawPageId = typeof (page.pageId ?? page.page_id) === "string"
+    ? String(page.pageId ?? page.page_id).trim()
+    : "";
+  const fromPageId = toPositiveInt(rawPageId.match(/^page-(\d+)$/i)?.[1], 0);
+  return fromPageId > 0 ? fromPageId : fallback;
+};
+
+const resolveLegacyPagePath = (page: Record<string, unknown>, projectDir: string, pageId: string): string => {
+  const rawPath = typeof (page.htmlPath ?? page.html_path) === "string"
+    ? String(page.htmlPath ?? page.html_path).trim()
+    : "";
+  if (!rawPath) return path.join(projectDir, `${pageId}.html`);
+  return path.isAbsolute(rawPath) ? rawPath : path.join(projectDir, rawPath);
+};
+
+const getTableColumns = async (
+  client: LibSqlClient,
+  tableName: "settings" | "messages" | "sessions" | "generation_pages"
+): Promise<Set<string>> => {
+  const result = await client.execute(`PRAGMA table_info(${tableName})`);
+  const rows = Array.isArray((result as { rows?: unknown[] }).rows)
+    ? ((result as { rows?: unknown[] }).rows as unknown[])
+    : [];
+  const columns = new Set<string>();
+  for (const row of rows) {
+    if (row && typeof row === "object" && "name" in row) {
+      const name = (row as { name?: unknown }).name;
+      if (typeof name === "string" && name.trim().length > 0) {
+        columns.add(name.trim());
+      }
+      continue;
+    }
+    if (Array.isArray(row) && typeof row[1] === "string" && row[1].trim().length > 0) {
+      columns.add(row[1].trim());
+    }
+  }
+  return columns;
+};
+
+const enforceSettingsSchema = async (client: LibSqlClient): Promise<void> => {
+  await client.execute(SETTINGS_TABLE_SQL);
+  const columns = await getTableColumns(client, "settings");
+  if (!columns.has("value")) {
+    await client.execute(`ALTER TABLE settings ADD COLUMN value TEXT NOT NULL DEFAULT '""'`);
+  }
+  if (!columns.has("updated_at")) {
+    await client.execute("ALTER TABLE settings ADD COLUMN updated_at INTEGER NOT NULL DEFAULT 0");
+  }
+  await client.execute("CREATE UNIQUE INDEX IF NOT EXISTS idx_settings_key ON settings(key)");
+};
+
+const enforceSessionsSchema = async (client: LibSqlClient): Promise<void> => {
+  const columns = await getTableColumns(client, "sessions");
+  if (!columns.has("style_id")) {
+    await client.execute("ALTER TABLE sessions ADD COLUMN style_id TEXT");
+  }
+};
+
+const enforceMessagesSchema = async (client: LibSqlClient): Promise<void> => {
+  await client.executeMultiple(MESSAGES_TABLE_SQL);
+  const columns = await getTableColumns(client, "messages");
+  if (!columns.has("chat_scope")) {
+    await client.execute(`ALTER TABLE messages ADD COLUMN chat_scope TEXT NOT NULL DEFAULT 'main'`);
+  }
+  if (!columns.has("page_id")) {
+    await client.execute("ALTER TABLE messages ADD COLUMN page_id TEXT");
+  }
+  if (!columns.has("selector")) {
+    await client.execute("ALTER TABLE messages ADD COLUMN selector TEXT");
+  }
+  if (!columns.has("image_paths")) {
+    await client.execute("ALTER TABLE messages ADD COLUMN image_paths TEXT");
+  }
+  if (!columns.has("type")) {
+    await client.execute("ALTER TABLE messages ADD COLUMN type TEXT");
+  }
+  if (!columns.has("tool_name")) {
+    await client.execute("ALTER TABLE messages ADD COLUMN tool_name TEXT");
+  }
+  if (!columns.has("tool_call_id")) {
+    await client.execute("ALTER TABLE messages ADD COLUMN tool_call_id TEXT");
+  }
+  if (!columns.has("token_count")) {
+    await client.execute("ALTER TABLE messages ADD COLUMN token_count INTEGER");
+  }
+  await client.execute("CREATE INDEX IF NOT EXISTS idx_messages_session ON messages(session_id, created_at)");
+  await client.execute("CREATE INDEX IF NOT EXISTS idx_messages_session_scope ON messages(session_id, chat_scope, page_id, created_at)");
+  await client.execute("CREATE INDEX IF NOT EXISTS idx_messages_session_only ON messages(session_id)");
+};
+
+const enforceGenerationSchema = async (client: LibSqlClient): Promise<void> => {
+  const columns = await getTableColumns(client, "generation_pages");
+  if (!columns.has("content_outline")) {
+    await client.execute("ALTER TABLE generation_pages ADD COLUMN content_outline TEXT");
+  }
+  await client.execute("CREATE INDEX IF NOT EXISTS idx_generation_runs_session ON generation_runs(session_id, created_at)");
+  await client.execute("CREATE INDEX IF NOT EXISTS idx_generation_pages_run ON generation_pages(run_id, page_number)");
+  await client.execute("CREATE INDEX IF NOT EXISTS idx_generation_pages_session_status ON generation_pages(session_id, status, page_number)");
+};
+
+const ensureDefaultSettings = async (client: LibSqlClient): Promise<void> => {
+  const now = Math.floor(Date.now() / 1000);
+  const defaults = [
+    { key: "provider", value: '"openai"' },
+    { key: "theme", value: '"light"' },
+    { key: "auto_save", value: "true" },
+  ];
+
+  for (const { key, value } of defaults) {
+    await client.execute({
+      sql: "INSERT OR IGNORE INTO settings (key, value, updated_at) VALUES (?, ?, ?)",
+      args: [key, value, now],
+    });
+  }
+};
+
+const resolveLegacyProjectDir = async (
+  client: LibSqlClient,
+  sessionId: string,
+  metadata: Record<string, unknown>,
+  resolveStoragePath: () => Promise<string>
+): Promise<string> => {
+  const projectResult = await client.execute({
+    sql: "SELECT output_path FROM projects WHERE session_id = ? LIMIT 1",
+    args: [sessionId],
+  }).catch(() => ({ rows: [] as unknown[] }));
+  const outputPath = getRowValue(projectResult.rows?.[0], "output_path");
+  if (typeof outputPath === "string" && outputPath.trim().length > 0) {
+    return outputPath.trim();
+  }
+  if (typeof metadata.indexPath === "string" && metadata.indexPath.trim().length > 0) {
+    return path.dirname(metadata.indexPath.trim());
+  }
+  const storagePath = await resolveStoragePath().catch(() => "");
+  return path.join(storagePath || process.cwd(), sessionId);
+};
+
+const upsertPatchedGenerationPage = async (
+  db: DrizzleDb,
+  data: {
+    runId: string;
+    sessionId: string;
+    pageId: string;
+    pageNumber: number;
+    title: string;
+    contentOutline?: string | null;
+    htmlPath?: string | null;
+    status: GenerationPageStatus;
+    error?: string | null;
+    retryCount?: number;
+  }
+): Promise<void> => {
+  const now = Math.floor(Date.now() / 1000);
+  const id = `${data.runId}:${data.pageId}`;
+  const values = {
+    id,
+    runId: data.runId,
+    sessionId: data.sessionId,
+    pageId: data.pageId,
+    pageNumber: data.pageNumber,
+    title: data.title,
+    contentOutline: data.contentOutline || null,
+    htmlPath: data.htmlPath || null,
+    status: data.status,
+    error: data.error || null,
+    retryCount: Math.max(0, Math.floor(data.retryCount || 0)),
+    createdAt: now,
+    updatedAt: now,
+  };
+  await db.insert(schema.generationPages).values(values).onConflictDoUpdate({
+    target: schema.generationPages.id,
+    set: {
+      pageNumber: values.pageNumber,
+      title: values.title,
+      contentOutline: values.contentOutline,
+      htmlPath: values.htmlPath,
+      status: values.status,
+      error: values.error,
+      retryCount: values.retryCount,
+      updatedAt: now,
+    },
+  }).run();
+};
+
+const patchGenerationRecordsFromMetadata = async (args: {
+  client: LibSqlClient;
+  db: DrizzleDb;
+  resolveStoragePath: () => Promise<string>;
+}): Promise<void> => {
+  const { client, db, resolveStoragePath } = args;
+  const sessions = await client.execute(`
+    SELECT id, page_count, status, metadata, updated_at
+    FROM sessions
+    WHERE metadata IS NOT NULL
+      AND TRIM(metadata) <> ''
+      AND NOT EXISTS (
+        SELECT 1 FROM generation_runs WHERE generation_runs.session_id = sessions.id
+      )
+    ORDER BY updated_at DESC
+  `);
+
+  for (const row of sessions.rows || []) {
+    const sessionId = String(getRowValue(row, "id") || "");
+    if (!sessionId) continue;
+    const metadata = parseJsonObject(getRowValue(row, "metadata"));
+    const generatedPages = Array.isArray(metadata.generatedPages)
+      ? metadata.generatedPages.filter((page): page is Record<string, unknown> => Boolean(page) && typeof page === "object" && !Array.isArray(page))
+      : [];
+    const failedPages = Array.isArray(metadata.failedPages)
+      ? metadata.failedPages.filter((page): page is Record<string, unknown> => Boolean(page) && typeof page === "object" && !Array.isArray(page))
+      : [];
+    if (generatedPages.length === 0 && failedPages.length === 0) continue;
+
+    const projectDir = await resolveLegacyProjectDir(client, sessionId, metadata, resolveStoragePath);
+    const pageMap = new Map<string, {
+      pageId: string;
+      pageNumber: number;
+      title: string;
+      contentOutline: string;
+      htmlPath: string;
+      status: GenerationPageStatus;
+      error: string | null;
+      retryCount: number;
+    }>();
+
+    generatedPages.forEach((page, index) => {
+      const pageNumber = inferPageNumber(page, index + 1);
+      const rawPageId = typeof (page.pageId ?? page.page_id) === "string"
+        ? String(page.pageId ?? page.page_id).trim()
+        : "";
+      const pageId = rawPageId || `page-${pageNumber}`;
+      pageMap.set(pageId, {
+        pageId,
+        pageNumber,
+        title: String(page.title || `第 ${pageNumber} 页`),
+        contentOutline: String(page.contentOutline ?? page.content_outline ?? ""),
+        htmlPath: resolveLegacyPagePath(page, projectDir, pageId),
+        status: "completed",
+        error: null,
+        retryCount: toPositiveInt(page.retryCount ?? page.retry_count, 0),
+      });
+    });
+
+    failedPages.forEach((page, index) => {
+      const pageNumber = inferPageNumber(page, generatedPages.length + index + 1);
+      const rawPageId = typeof (page.pageId ?? page.page_id) === "string"
+        ? String(page.pageId ?? page.page_id).trim()
+        : "";
+      const pageId = rawPageId || `page-${pageNumber}`;
+      pageMap.set(pageId, {
+        pageId,
+        pageNumber,
+        title: String(page.title || `第 ${pageNumber} 页`),
+        contentOutline: String(page.contentOutline ?? page.content_outline ?? ""),
+        htmlPath: resolveLegacyPagePath(page, projectDir, pageId),
+        status: "failed",
+        error: String(page.reason || page.error || "旧 metadata 记录的失败页"),
+        retryCount: toPositiveInt(page.retryCount ?? page.retry_count, 0),
+      });
+    });
+
+    const pages = Array.from(pageMap.values()).sort((a, b) => a.pageNumber - b.pageNumber);
+    if (pages.length === 0) continue;
+
+    const generatedCount = pages.filter((page) => page.status === "completed").length;
+    const failedCount = pages.filter((page) => page.status === "failed").length;
+    const totalPages = Math.max(toPositiveInt(getRowValue(row, "page_count"), 0), pages.length);
+    const runStatus: GenerationRunStatus =
+      failedCount > 0
+        ? generatedCount > 0 ? "partial" : "failed"
+        : "completed";
+    const runId = `patch-${sessionId}`;
+    const updatedAt = toPositiveInt(getRowValue(row, "updated_at"), Math.floor(Date.now() / 1000));
+
+    await db.insert(schema.generationRuns).values({
+      id: runId,
+      sessionId,
+      mode: "generate",
+      status: runStatus,
+      totalPages,
+      error: failedCount > 0 ? `${failedCount} page(s) failed in legacy metadata` : null,
+      metadata: JSON.stringify({
+        source: "metadata_patch",
+        generatedCount,
+        failedCount,
+        patchedAt: new Date().toISOString(),
+      }),
+      createdAt: updatedAt,
+      updatedAt: Math.floor(Date.now() / 1000),
+    }).onConflictDoNothing().run();
+
+    for (const page of pages) {
+      await upsertPatchedGenerationPage(db, {
+        runId,
+        sessionId,
+        pageId: page.pageId,
+        pageNumber: page.pageNumber,
+        title: page.title,
+        contentOutline: page.contentOutline,
+        htmlPath: page.htmlPath,
+        status: page.status,
+        error: page.error,
+        retryCount: page.retryCount,
+      });
+    }
+  }
+};
+
+export const runDatabasePatches = async (args: {
+  client: LibSqlClient;
+  db: DrizzleDb;
+  resolveStoragePath: () => Promise<string>;
+}): Promise<void> => {
+  const { client, db, resolveStoragePath } = args;
+  await client.executeMultiple(INIT_SQL);
+  await enforceSessionsSchema(client);
+  await enforceSettingsSchema(client);
+  await enforceMessagesSchema(client);
+  await enforceGenerationSchema(client);
+  await client.execute("PRAGMA foreign_keys = ON;");
+  await ensureDefaultSettings(client);
+  await patchGenerationRecordsFromMetadata({ client, db, resolveStoragePath });
+};

--- a/src/main/db/schema.ts
+++ b/src/main/db/schema.ts
@@ -43,6 +43,34 @@ export const projects = sqliteTable("projects", {
   updatedAt: integer("updated_at").notNull(),
 });
 
+export const generationRuns = sqliteTable("generation_runs", {
+  id: text("id").primaryKey(),
+  sessionId: text("session_id").notNull().references(() => sessions.id, { onDelete: "cascade" }),
+  mode: text("mode").notNull().default("generate"),
+  status: text("status").notNull().default("running"),
+  totalPages: integer("total_pages").notNull().default(0),
+  error: text("error"),
+  metadata: text("metadata"),
+  createdAt: integer("created_at").notNull(),
+  updatedAt: integer("updated_at").notNull(),
+});
+
+export const generationPages = sqliteTable("generation_pages", {
+  id: text("id").primaryKey(),
+  runId: text("run_id").notNull().references(() => generationRuns.id, { onDelete: "cascade" }),
+  sessionId: text("session_id").notNull().references(() => sessions.id, { onDelete: "cascade" }),
+  pageId: text("page_id").notNull(),
+  pageNumber: integer("page_number").notNull(),
+  title: text("title").notNull(),
+  contentOutline: text("content_outline"),
+  htmlPath: text("html_path"),
+  status: text("status").notNull().default("pending"),
+  error: text("error"),
+  retryCount: integer("retry_count").notNull().default(0),
+  createdAt: integer("created_at").notNull(),
+  updatedAt: integer("updated_at").notNull(),
+});
+
 export const settings = sqliteTable("settings", {
   key: text("key").primaryKey(),
   value: text("value").notNull(),
@@ -85,6 +113,8 @@ export const styles = sqliteTable("styles", {
 export type Session = typeof sessions.$inferSelect;
 export type Message = typeof messages.$inferSelect;
 export type Project = typeof projects.$inferSelect;
+export type GenerationRun = typeof generationRuns.$inferSelect;
+export type GenerationPage = typeof generationPages.$inferSelect;
 export type MemorySummary = typeof memorySummaries.$inferSelect;
 export type UserPreference = typeof userPreferences.$inferSelect;
 
@@ -92,3 +122,5 @@ export type SessionStatus = "active" | "completed" | "failed" | "archived";
 export type MessageRole = "user" | "assistant" | "system" | "tool";
 export type MessageType = "text" | "tool_call" | "tool_result" | "stream_chunk";
 export type ChatScope = "main" | "page";
+export type GenerationRunStatus = "running" | "completed" | "failed" | "partial";
+export type GenerationPageStatus = "pending" | "running" | "completed" | "failed";

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -7,6 +7,7 @@ import { PPTDatabase } from './db/database'
 import { AgentManager } from './agent'
 import { setupIPC } from './ipc'
 import { setStyleDb } from './utils/style-skills'
+import type { UpdateAvailablePayload } from '@shared/app-update'
 
 let mainWindow: BrowserWindow | null = null
 let db: PPTDatabase | null = null
@@ -21,6 +22,8 @@ const BASE_MIN_HEIGHT = 620
 const TITLEBAR_HEIGHT = 48
 const TITLEBAR_BACKGROUND = '#f4eddf'
 const TITLEBAR_SYMBOL_COLOR = '#5d6b4d'
+const GITHUB_LATEST_RELEASE_API = 'https://api.github.com/repos/arcsin1/oh-my-ppt/releases/latest'
+const GITHUB_RELEASES_URL = 'https://github.com/arcsin1/oh-my-ppt/releases'
 
 function resolveWindowBounds() {
   const workArea = screen.getPrimaryDisplay().workAreaSize
@@ -69,6 +72,91 @@ function configureLogging(): void {
     env: is.dev ? 'dev' : 'prod',
     version: app.getVersion(),
     file: log.transports.file.getFile().path,
+  })
+}
+
+function parseVersion(version: string): number[] {
+  return version
+    .trim()
+    .replace(/^v/i, '')
+    .split(/[.-]/)
+    .slice(0, 3)
+    .map((part) => {
+      const value = Number.parseInt(part, 10)
+      return Number.isFinite(value) ? value : 0
+    })
+}
+
+function isNewerVersion(latestVersion: string, currentVersion: string): boolean {
+  const latest = parseVersion(latestVersion)
+  const current = parseVersion(currentVersion)
+  for (let index = 0; index < Math.max(latest.length, current.length, 3); index += 1) {
+    const latestPart = latest[index] ?? 0
+    const currentPart = current[index] ?? 0
+    if (latestPart > currentPart) return true
+    if (latestPart < currentPart) return false
+  }
+  return false
+}
+
+async function fetchLatestRelease(): Promise<UpdateAvailablePayload | null> {
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), 8000)
+  try {
+    const response = await fetch(GITHUB_LATEST_RELEASE_API, {
+      headers: {
+        Accept: 'application/vnd.github+json',
+        'User-Agent': `${APP_NAME}/${app.getVersion()}`
+      },
+      signal: controller.signal
+    })
+    if (!response.ok) {
+      log.warn('[update] latest release request failed', {
+        status: response.status,
+        statusText: response.statusText
+      })
+      return null
+    }
+    const release = (await response.json()) as {
+      tag_name?: string
+      html_url?: string
+      name?: string
+      published_at?: string
+      draft?: boolean
+      prerelease?: boolean
+    }
+    const latestVersion = String(release.tag_name || '').trim()
+    const currentVersion = app.getVersion()
+    if (!latestVersion || release.draft || release.prerelease) return null
+    if (!isNewerVersion(latestVersion, currentVersion)) return null
+
+    return {
+      currentVersion,
+      latestVersion,
+      releaseUrl: release.html_url || GITHUB_RELEASES_URL,
+      releaseName: release.name,
+      publishedAt: release.published_at
+    }
+  } catch (error) {
+    log.warn('[update] latest release check failed', {
+      message: error instanceof Error ? error.message : String(error)
+    })
+    return null
+  } finally {
+    clearTimeout(timeout)
+  }
+}
+
+function scheduleUpdateNotification(window: BrowserWindow): void {
+  if (is.dev) return
+  window.webContents.once('did-finish-load', () => {
+    setTimeout(() => {
+      void fetchLatestRelease().then((update) => {
+        if (!update || window.isDestroyed() || window.webContents.isDestroyed()) return
+        log.info('[update] new release available', update)
+        window.webContents.send('app:update-available', update)
+      })
+    }, 2500)
   })
 }
 
@@ -170,6 +258,7 @@ app.whenReady().then(async () => {
 
   if (mainWindow && db && agentManager) {
     setupIPC(mainWindow, db, agentManager)
+    scheduleUpdateNotification(mainWindow)
   }
 
   electronApp.setAppUserModelId('com.ohmyppt.app')

--- a/src/main/ipc/generate.ts
+++ b/src/main/ipc/generate.ts
@@ -162,12 +162,30 @@ const normalizeDesignContract = (value: unknown): DesignContract => {
   };
 };
 
+const unwrapJsonLikeString = (value: string): string => {
+  const source = value.trim();
+  if (source.length < 2 || !source.startsWith("\"") || !source.endsWith("\"")) {
+    return source;
+  }
+  const inner = source
+    .slice(1, -1)
+    .replace(/\\"/g, "\"")
+    .replace(/\\n/g, "\n")
+    .replace(/\\r/g, "\r")
+    .replace(/\\t/g, "\t")
+    .trim();
+  return inner.startsWith("{") || inner.startsWith("[") || inner.startsWith("```")
+    ? inner
+    : source;
+};
+
 const parseModelJson = (responseText: string): unknown => {
   let source = responseText.trim();
+  let lastError: unknown;
 
-  for (let attempt = 0; attempt < 3; attempt += 1) {
-    const candidates = [source, extractJsonBlock(source)];
-    let lastError: unknown;
+  for (let attempt = 0; attempt < 6; attempt += 1) {
+    const candidates = Array.from(new Set([source, extractJsonBlock(source)]));
+    let decodedJsonString = false;
 
     for (const candidate of candidates) {
       try {
@@ -177,36 +195,36 @@ const parseModelJson = (responseText: string): unknown => {
         }
         source = parsed.trim();
         lastError = null;
+        decodedJsonString = true;
         break;
       } catch (err) {
         lastError = err;
       }
     }
 
-    if (lastError === null) {
+    if (decodedJsonString) {
       continue;
     }
 
-    const preview = source.length > 200 ? `${source.slice(0, 200)}…` : source;
-    throw new Error(
-      `LLM 返回的 JSON 解析失败: ${lastError instanceof Error ? lastError.message : String(lastError)}. 原始文本预览: ${preview}`
-    );
+    const unwrapped = unwrapJsonLikeString(source);
+    if (unwrapped !== source) {
+      source = unwrapped;
+      continue;
+    }
+
+    const block = extractJsonBlock(source);
+    if (block !== source) {
+      source = block;
+      continue;
+    }
+
+    break;
   }
 
-  try {
-    return JSON.parse(extractJsonBlock(source)) as unknown;
-  } catch (err) {
-    try {
-      const parsed = JSON.parse(source) as unknown;
-      if (typeof parsed !== "string") return parsed;
-    } catch {
-      // The detailed error below uses the first parse failure.
-    }
-    const preview = source.length > 200 ? `${source.slice(0, 200)}…` : source;
-    throw new Error(
-      `LLM 返回的 JSON 解析失败: ${err instanceof Error ? err.message : String(err)}. 原始文本预览: ${preview}`
-    );
-  }
+  const preview = source.length > 200 ? `${source.slice(0, 200)}…` : source;
+  throw new Error(
+    `LLM 返回的 JSON 解析失败: ${lastError instanceof Error ? lastError.message : String(lastError)}. 原始文本预览: ${preview}`
+  );
 };
 
 const SUMMARY_PUNCT_ONLY_RE = /^[\s.。!！?？,，;；:：、~\-—_`'"“”‘’()（）\[\]【】]+$/;
@@ -235,6 +253,7 @@ export const planDeckWithLLM = async (args: {
   apiKey: string;
   model: string;
   baseUrl: string;
+  temperature?: number;
   styleId: string | null | undefined;
   totalPages: number;
   topic: string;
@@ -243,7 +262,7 @@ export const planDeckWithLLM = async (args: {
   runId?: string;
   signal?: AbortSignal;
 }): Promise<OutlineItem[]> => {
-  const client = resolveModel(args.provider, args.apiKey, args.model, args.baseUrl);
+  const client = resolveModel(args.provider, args.apiKey, args.model, args.baseUrl, args.temperature);
   const systemPrompt = buildPlanningSystemPrompt(args.totalPages);
   const userPrompt = buildPlanningUserPrompt({
     topic: args.topic,
@@ -267,6 +286,7 @@ export const planDeckWithLLM = async (args: {
   log.info("[llm] invoke plan_deck", {
     provider: args.provider,
     model: args.model,
+    temperature: args.temperature ?? null,
     styleId: args.styleId || "",
     totalPages: args.totalPages,
     topic: args.topic,
@@ -341,6 +361,7 @@ export const buildDesignContractWithLLM = async (args: {
   apiKey: string;
   model: string;
   baseUrl: string;
+  temperature?: number;
   styleId: string | null | undefined;
   styleSkillPrompt: string;
   totalPages: number;
@@ -348,7 +369,7 @@ export const buildDesignContractWithLLM = async (args: {
   runId?: string;
   signal?: AbortSignal;
 }): Promise<DesignContract> => {
-  const client = resolveModel(args.provider, args.apiKey, args.model, args.baseUrl);
+  const client = resolveModel(args.provider, args.apiKey, args.model, args.baseUrl, args.temperature);
   const totalPages = Math.max(1, args.totalPages);
   args.emit?.({
     type: "llm_status",
@@ -406,6 +427,7 @@ export const buildDesignContractWithLLM = async (args: {
     log.warn("[llm] design_contract fallback", {
       provider: args.provider,
       model: args.model,
+      temperature: args.temperature ?? null,
       styleId: args.styleId || "",
       message: error instanceof Error ? error.message : String(error),
     });
@@ -419,6 +441,7 @@ export const runDeepAgentDeckGeneration = async (args: {
   apiKey: string;
   model: string;
   baseUrl: string;
+  temperature?: number;
   styleId: string | null | undefined;
   styleSkillPrompt: string;
   topic: string;
@@ -426,26 +449,54 @@ export const runDeepAgentDeckGeneration = async (args: {
   userMessage: string;
   outlineTitles: string[];
   outlineItems: OutlineItem[];
+  pageTasks?: Array<{
+    pageNumber: number;
+    pageId: string;
+    title: string;
+    contentOutline?: string | null;
+  }>;
   designContract: DesignContract;
   projectDir: string;
   indexPath: string;
   pageFileMap: Record<string, string>;
   agentManager: AgentManager;
   emit?: (chunk: GenerateChunkEvent) => void;
+  onPageCompleted?: (page: {
+    pageNumber: number;
+    pageId: string;
+    title: string;
+    contentOutline: string;
+    htmlPath: string;
+  }) => Promise<void>;
+  onPageFailed?: (page: {
+    pageNumber: number;
+    pageId: string;
+    title: string;
+    contentOutline: string;
+    htmlPath: string;
+    reason: string;
+  }) => Promise<void>;
   runId?: string;
   signal?: AbortSignal;
 }): Promise<{
   summary: string;
   failedPages: Array<{ pageId: string; title: string; reason: string }>;
 }> => {
-  const totalPages = args.outlineTitles.length;
+  const pageRefs = (args.pageTasks && args.pageTasks.length > 0)
+    ? args.pageTasks.map((page) => ({
+        pageNumber: page.pageNumber,
+        pageId: page.pageId,
+        title: page.title,
+        outline: page.contentOutline || "",
+      }))
+    : args.outlineTitles.map((title, index) => ({
+        pageNumber: index + 1,
+        pageId: `page-${index + 1}`,
+        title,
+        outline: args.outlineItems[index]?.contentOutline || "",
+      }));
+  const totalPages = pageRefs.length;
   const clampProgress = (value: number) => Math.max(0, Math.min(100, Math.round(value)));
-  const pageRefs = args.outlineTitles.map((title, index) => ({
-    pageNumber: index + 1,
-    pageId: `page-${index + 1}`,
-    title,
-    outline: args.outlineItems[index]?.contentOutline || "",
-  }));
   const pageSummaryMap = new Map<number, string>();
   const useDualWorkerQueue = totalPages >= 3;
   const pageProgressMap = new Map<string, number>();
@@ -528,6 +579,7 @@ export const runDeepAgentDeckGeneration = async (args: {
     sessionId: args.sessionId,
     provider: args.provider,
     model: args.model,
+    temperature: args.temperature ?? null,
     styleId: args.styleId || "",
     projectDir: args.projectDir,
     indexPath: args.indexPath,
@@ -588,6 +640,7 @@ export const runDeepAgentDeckGeneration = async (args: {
       apiKey: args.apiKey,
       model: args.model,
       baseUrl: args.baseUrl,
+      temperature: args.temperature,
       styleId: args.styleId,
       context: {
         sessionId: args.sessionId,
@@ -691,6 +744,14 @@ export const runDeepAgentDeckGeneration = async (args: {
           if (!isMeaningfulSummary(content)) return;
           pageSummaryFromMessage = content.trim();
         },
+      });
+
+      await args.onPageCompleted?.({
+        pageNumber: page.pageNumber,
+        pageId: page.pageId,
+        title: page.title,
+        contentOutline: page.outline,
+        htmlPath: currentPagePath,
       });
 
       setPageProgress(page.pageId, 100);
@@ -808,9 +869,22 @@ export const runDeepAgentDeckGeneration = async (args: {
           pageNumber: page.pageNumber,
           title: page.title,
         });
-        const summary = await generateSinglePageWithRetry(page, workerLabel);
-        if (summary) {
-          pageSummaryMap.set(page.pageNumber, `第 ${page.pageNumber} 页：${summary}`);
+        try {
+          const summary = await generateSinglePageWithRetry(page, workerLabel);
+          if (summary) {
+            pageSummaryMap.set(page.pageNumber, `第 ${page.pageNumber} 页：${summary}`);
+          }
+        } catch (error) {
+          const reason = error instanceof Error ? error.message : String(error);
+          await args.onPageFailed?.({
+            pageNumber: page.pageNumber,
+            pageId: page.pageId,
+            title: page.title,
+            contentOutline: page.outline,
+            htmlPath: args.pageFileMap[page.pageId] || "",
+            reason,
+          });
+          throw error;
         }
       })
     )
@@ -856,6 +930,7 @@ export const runDeepAgentEdit = async (args: {
   apiKey: string;
   model: string;
   baseUrl: string;
+  temperature?: number;
   styleId: string | null | undefined;
   styleSkillPrompt: string;
   topic: string;
@@ -884,6 +959,7 @@ export const runDeepAgentEdit = async (args: {
     apiKey: args.apiKey,
     model: args.model,
     baseUrl: args.baseUrl,
+    temperature: args.temperature,
     styleId: args.styleId,
     context: {
       mode: "edit",
@@ -932,6 +1008,7 @@ export const runDeepAgentEdit = async (args: {
     sessionId: args.sessionId,
     provider: args.provider,
     model: args.model,
+    temperature: args.temperature ?? null,
     styleId: args.styleId || "",
     projectDir: args.projectDir,
     indexPath: args.indexPath,

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -34,6 +34,7 @@ import { buildDesignContractWithLLM, planDeckWithLLM, runDeepAgentDeckGeneration
 export function setupIPC(mainWindow: BrowserWindow, db: PPTDatabase, agentManager: AgentManager) {
   const ENCRYPTED_API_KEY_PREFIX = "enc:v1:";
   const MAX_SESSION_RUN_EVENTS = 500;
+  const FINISHED_SESSION_RUN_STATE_TTL_MS = 30 * 60 * 1000;
   const ALLOWED_IMAGE_EXTENSIONS = new Set([".png", ".jpg", ".jpeg", ".webp", ".gif", ".svg"]);
   const ALLOWED_DOC_EXTENSIONS = new Set([".md", ".txt", ".text"]);
   const IMAGE_MIME_BY_EXT: Record<string, string> = {
@@ -53,11 +54,157 @@ export function setupIPC(mainWindow: BrowserWindow, db: PPTDatabase, agentManage
     if (!htmlPath || !fs.existsSync(htmlPath)) return undefined;
     return pathToFileURL(htmlPath).toString();
   };
+  const validateProjectIndexHtml = (html: string): string[] => {
+    const errors: string[] = [];
+    if (!/<html[\s>]/i.test(html)) errors.push("index.html 缺少 <html> 标签");
+    if (!/<body[\s>]/i.test(html)) errors.push("index.html 缺少 <body> 标签");
+    if (!/<iframe\b[^>]*class=["'][^"']*\bppt-preview-frame\b/i.test(html)) {
+      errors.push("index.html 缺少页面预览 iframe");
+    }
+    if (!/id=["']pages-data["']/i.test(html)) {
+      errors.push("index.html 缺少 pages-data 页面数据");
+    }
+    if (!/const\s+pages\s*=\s*JSON\.parse/i.test(html)) {
+      errors.push("index.html 缺少页面数据解析逻辑");
+    }
+    if (!/function\s+applyPage\s*\(/i.test(html)) {
+      errors.push("index.html 缺少页面切换逻辑");
+    }
+    return errors;
+  };
+  const parseSessionMetadataObject = (value: unknown): Record<string, unknown> => {
+    if (typeof value !== "string" || value.trim().length === 0) return {};
+    try {
+      const parsed = JSON.parse(value) as unknown;
+      return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+        ? parsed as Record<string, unknown>
+        : {};
+    } catch {
+      return {};
+    }
+  };
+
+  const buildSessionGenerationSnapshot = async (
+    session: Record<string, unknown> | null | undefined,
+    options?: { includeHtml?: boolean }
+  ): Promise<{
+    session: Record<string, unknown> | null | undefined;
+    pages: Array<{
+      pageNumber: number;
+      title: string;
+      html: string;
+      htmlPath?: string;
+      pageId?: string;
+      sourceUrl?: string;
+      status?: string;
+      error?: string | null;
+    }>;
+  }> => {
+    if (!session) return { session, pages: [] };
+    const sessionId = String(session.id || "").trim();
+    if (!sessionId) return { session, pages: [] };
+
+    const metadata = parseSessionMetadataObject(session.metadata);
+    const generationSnapshot = await db.listLatestGenerationPageSnapshot(sessionId);
+    if (generationSnapshot.length === 0) {
+      return { session, pages: [] };
+    }
+
+    const project = await db.getProject(sessionId);
+    const metadataIndexPath =
+      typeof metadata.indexPath === "string" && metadata.indexPath.trim().length > 0
+        ? metadata.indexPath.trim()
+        : "";
+    const projectDir =
+      typeof project?.output_path === "string" && project.output_path.trim().length > 0
+        ? project.output_path.trim()
+        : metadataIndexPath
+          ? path.dirname(metadataIndexPath)
+          : path.join(await resolveStoragePath(), sessionId);
+    const indexPath = metadataIndexPath || path.join(projectDir, "index.html");
+    const completedPagesForMetadata: Array<{
+      pageNumber: number;
+      title: string;
+      pageId: string;
+      htmlPath: string;
+    }> = [];
+    const failedPagesForMetadata: Array<{
+      pageId: string;
+      title: string;
+      reason: string;
+    }> = [];
+    const pages: Array<{
+      pageNumber: number;
+      title: string;
+      html: string;
+      htmlPath?: string;
+      pageId?: string;
+      sourceUrl?: string;
+      status?: string;
+      error?: string | null;
+    }> = [];
+
+    for (const page of generationSnapshot) {
+      const pageId = page.page_id || `page-${page.page_number}`;
+      const title = page.title || `第 ${page.page_number} 页`;
+      const htmlPath = page.html_path || path.join(projectDir, `${pageId}.html`);
+      const html = options?.includeHtml && fs.existsSync(htmlPath)
+        ? await fs.promises.readFile(htmlPath, "utf-8")
+        : "";
+      if (page.status === "completed") {
+        completedPagesForMetadata.push({
+          pageNumber: page.page_number,
+          title,
+          pageId,
+          htmlPath,
+        });
+      } else if (page.status === "failed") {
+        failedPagesForMetadata.push({
+          pageId,
+          title,
+          reason: page.error || "页面仍需修复",
+        });
+      }
+
+      pages.push({
+        pageNumber: page.page_number,
+        title,
+        html: options?.includeHtml ? html : "",
+        htmlPath,
+        pageId,
+        sourceUrl: getPageSourceUrl(htmlPath),
+        status: page.status,
+        error: page.error,
+      });
+    }
+
+    const synthesizedMetadata = {
+      ...metadata,
+      lastRunId: generationSnapshot[0]?.run_id || metadata.lastRunId,
+      entryMode: "multi_page",
+      generatedPages: completedPagesForMetadata.sort((a, b) => a.pageNumber - b.pageNumber),
+      failedPages: failedPagesForMetadata.sort((a, b) => {
+        const aNumber = Number(a.pageId.match(/^page-(\d+)$/i)?.[1] || 0);
+        const bNumber = Number(b.pageId.match(/^page-(\d+)$/i)?.[1] || 0);
+        return aNumber - bNumber;
+      }),
+      indexPath,
+      projectId: project?.id || metadata.projectId,
+    };
+
+    return {
+      session: {
+        ...session,
+        metadata: JSON.stringify(synthesizedMetadata),
+      },
+      pages: pages.sort((a, b) => a.pageNumber - b.pageNumber),
+    };
+  };
 
   type SessionRunState = {
     sessionId: string;
     runId: string;
-    mode: "generate" | "edit";
+    mode: "generate" | "edit" | "retry";
     status: "running" | "completed" | "failed";
     progress: number;
     totalPages: number;
@@ -67,6 +214,15 @@ export function setupIPC(mainWindow: BrowserWindow, db: PPTDatabase, agentManage
     updatedAt: number;
   };
   const sessionRunStates = new Map<string, SessionRunState>();
+
+  const pruneFinishedSessionRunStates = (now = Date.now()): void => {
+    for (const [sessionId, state] of sessionRunStates) {
+      if (state.status === "running") continue;
+      if (now - state.updatedAt > FINISHED_SESSION_RUN_STATE_TTL_MS) {
+        sessionRunStates.delete(sessionId);
+      }
+    }
+  };
 
   const summarizeGenerateChunk = (chunk: GenerateChunkEvent) => {
     switch (chunk.type) {
@@ -119,10 +275,11 @@ export function setupIPC(mainWindow: BrowserWindow, db: PPTDatabase, agentManage
   const beginSessionRunState = (args: {
     sessionId: string;
     runId: string;
-    mode: "generate" | "edit";
+    mode: "generate" | "edit" | "retry";
     totalPages: number;
   }): void => {
     const now = Date.now();
+    pruneFinishedSessionRunStates(now);
     sessionRunStates.set(args.sessionId, {
       sessionId: args.sessionId,
       runId: args.runId,
@@ -560,6 +717,12 @@ export function setupIPC(mainWindow: BrowserWindow, db: PPTDatabase, agentManage
     }
   };
 
+  const PLANNER_TEMPERATURE = 0.1;
+  const DESIGN_CONTRACT_TEMPERATURE = 0.35;
+  const PAGE_GENERATION_TEMPERATURE = 0.7;
+  const PAGE_EDIT_WITH_SELECTOR_TEMPERATURE = 0.3;
+  const PAGE_EDIT_DEFAULT_TEMPERATURE = 0.55;
+
   const resolveSessionAssetSourcePath = (fileName: string): string => {
     const baseDir = is.dev
       ? path.join(process.cwd(), "resources")
@@ -888,7 +1051,7 @@ export function setupIPC(mainWindow: BrowserWindow, db: PPTDatabase, agentManage
     }
   };
 
-  type GenerateMode = "generate" | "edit";
+  type GenerateMode = "generate" | "edit" | "retry";
   type GenerateChatType = "main" | "page";
 
   type GenerationContext = {
@@ -903,6 +1066,7 @@ export function setupIPC(mainWindow: BrowserWindow, db: PPTDatabase, agentManage
     elementText?: string;
     session: Awaited<ReturnType<PPTDatabase["getSession"]>>;
     sessionRecord: Record<string, unknown>;
+    previousSessionStatus: string;
     entry: ReturnType<AgentManager["beginRun"]> extends infer T ? NonNullable<T> : never;
     runId: string;
     styleId: string;
@@ -957,7 +1121,8 @@ export function setupIPC(mainWindow: BrowserWindow, db: PPTDatabase, agentManage
 
   const resolveGenerationContext = async (
     _event: Electron.IpcMainInvokeEvent,
-    payload: unknown
+    payload: unknown,
+    options?: { persistUserMessage?: boolean; mode?: GenerateMode }
   ): Promise<GenerationContext> => {
     const input = payload as GenerateStartPayload;
     const sessionId = String(input?.sessionId || "").trim();
@@ -970,9 +1135,10 @@ export function setupIPC(mainWindow: BrowserWindow, db: PPTDatabase, agentManage
       : [];
     const requestedType = input?.type === "page" ? "page" : input?.type === "deck" ? "deck" : undefined;
     const effectiveMode: GenerateMode =
-      requestedType === "page"
+      options?.mode ??
+      (requestedType === "page"
         ? "edit"
-        : "generate";
+        : "generate");
     const imagePaths = effectiveMode === "edit" ? rawImagePaths : [];
     const userMessage = `${rawUserMessage}${formatImagePathsForPrompt(imagePaths)}`;
     const selectedPageId =
@@ -1014,6 +1180,7 @@ export function setupIPC(mainWindow: BrowserWindow, db: PPTDatabase, agentManage
     const session = await db.getSession(sessionId);
     if (!session) throw new Error("Session not found");
     const sessionRecord = session as unknown as Record<string, unknown>;
+    const previousSessionStatus = String(sessionRecord.status || "active");
     const styleCatalog = listStyleCatalog();
     const defaultStyleId = styleCatalog.find((item) => item.styleKey === "minimal-white")?.id ?? styleCatalog[0]?.id ?? "";
     const styleIdRaw = typeof sessionRecord.styleId === "string" ? String(sessionRecord.styleId).trim() : "";
@@ -1034,17 +1201,23 @@ export function setupIPC(mainWindow: BrowserWindow, db: PPTDatabase, agentManage
     }
     await ensureSessionAssets(projectDir);
 
-    const provider = String(sessionRecord.provider || "openai");
     const settings = await db.getAllSettings();
-    const ensuredModel = String(sessionRecord.model || settings[`model_${provider}`] || "").trim();
-    if (!ensuredModel) {
+    const provider = String(settings.provider || "").trim();
+    if (!provider) {
+      throw new Error("请先前往系统设置选择 provider。");
+    }
+    const settingsModel = String(settings[`model_${provider}`] || "").trim();
+    const model = settingsModel;
+    const providerBaseUrl = String(settings[`base_url_${provider}`] || "").trim();
+    if (!model) {
       throw new Error("请先前往系统设置填写 model。");
     }
 
     agentManager.ensureSession({
       sessionId,
       provider,
-      model: ensuredModel,
+      model,
+      baseUrl: providerBaseUrl,
       projectDir,
     });
 
@@ -1057,8 +1230,6 @@ export function setupIPC(mainWindow: BrowserWindow, db: PPTDatabase, agentManage
     const totalPages = Number(sessionRecord.page_count ?? sessionRecord.pageCount);
 
     const apiKey = decryptApiKey(settings[`api_key_${provider}`]).trim();
-    const model = ensuredModel;
-    const providerBaseUrl = String(settings[`base_url_${provider}`] || "").trim();
     const projectId =
       existingProject?.id ??
       (await db.createProject({
@@ -1078,15 +1249,17 @@ export function setupIPC(mainWindow: BrowserWindow, db: PPTDatabase, agentManage
       throw new Error("chatType=page requires chatPageId or selectedPageId");
     }
 
-    await db.addMessage(sessionId, {
-      role: "user",
-      content: rawUserMessage,
-      type: "text",
-      chat_scope: normalizedChatType,
-      page_id: normalizedChatType === "page" ? normalizedChatPageId : undefined,
-      selector: normalizedChatType === "page" ? selector : undefined,
-      image_paths: imagePaths,
-    });
+    if (options?.persistUserMessage !== false) {
+      await db.addMessage(sessionId, {
+        role: "user",
+        content: rawUserMessage,
+        type: "text",
+        chat_scope: normalizedChatType,
+        page_id: normalizedChatType === "page" ? normalizedChatPageId : undefined,
+        selector: normalizedChatType === "page" ? selector : undefined,
+        image_paths: imagePaths,
+      });
+    }
     await db.updateSessionStatus(sessionId, "active");
 
     const topic = String(sessionRecord.topic || "当前主题");
@@ -1099,6 +1272,9 @@ export function setupIPC(mainWindow: BrowserWindow, db: PPTDatabase, agentManage
       styleId,
       styleKey: styleDetail.styleKey,
       styleLabel: styleDetail.label,
+      provider,
+      settingsModel,
+      model,
     });
 
     return {
@@ -1113,6 +1289,7 @@ export function setupIPC(mainWindow: BrowserWindow, db: PPTDatabase, agentManage
       elementText,
       session,
       sessionRecord,
+      previousSessionStatus,
       entry,
       runId,
       styleId,
@@ -1173,7 +1350,16 @@ export function setupIPC(mainWindow: BrowserWindow, db: PPTDatabase, agentManage
       styleId: context.styleId,
       message,
     });
-    await db.updateSessionStatus(context.sessionId, "failed");
+    const generationRun = await db.getGenerationRun(context.runId);
+    if (generationRun && generationRun.status === "running") {
+      await db.updateGenerationRunStatus(context.runId, "failed", message);
+    }
+    await db.updateSessionStatus(
+      context.sessionId,
+      (context.effectiveMode === "edit" || context.effectiveMode === "retry") && context.previousSessionStatus !== "active"
+        ? context.previousSessionStatus as "completed" | "failed" | "archived"
+        : "failed"
+    );
     await db.addMessage(context.sessionId, {
       role: "system",
       content: message,
@@ -1205,14 +1391,23 @@ export function setupIPC(mainWindow: BrowserWindow, db: PPTDatabase, agentManage
     let outlineTitles: string[] = context.userProvidedOutlineTitles;
     let pageRefs: Array<{ pageNumber: number; title: string; pageId: string; htmlPath: string }> = [];
     let savedDesignContract: DesignContract | undefined;
+    let metadataFailedPages: Array<{ pageId: string; title: string; reason: string }> = [];
     if (context.session?.metadata) {
       try {
         const metadata = JSON.parse(context.session.metadata) as {
           generatedPages?: Array<{ pageNumber: number; title: string; pageId?: string; htmlPath?: string }>;
+          failedPages?: Array<{ pageId?: string; title?: string; reason?: string }>;
         };
         if (outlineTitles.length === 0) {
           outlineTitles = (metadata.generatedPages || []).map((p) => p.title);
         }
+        metadataFailedPages = (metadata.failedPages || [])
+          .map((page) => ({
+            pageId: typeof page.pageId === "string" ? page.pageId.trim() : "",
+            title: typeof page.title === "string" ? page.title.trim() : "",
+            reason: typeof page.reason === "string" ? page.reason.trim() : "",
+          }))
+          .filter((page) => page.pageId.length > 0);
         pageRefs = (metadata.generatedPages || []).map((p, index) => {
           const pageId = p.pageId || `page-${p.pageNumber || index + 1}`;
           return {
@@ -1224,6 +1419,37 @@ export function setupIPC(mainWindow: BrowserWindow, db: PPTDatabase, agentManage
         });
       } catch {
         // ignore malformed metadata
+      }
+    }
+    const latestPageSnapshot = await db.listLatestGenerationPageSnapshot(context.sessionId);
+    const pageRefById = new Map(pageRefs.map((ref) => [ref.pageId, ref]));
+    for (const page of latestPageSnapshot) {
+      const pageId = page.page_id || `page-${page.page_number}`;
+      if (pageRefById.has(pageId)) continue;
+      const ref = {
+        pageNumber: page.page_number,
+        title: page.title || `第${page.page_number}页`,
+        pageId,
+        htmlPath: page.html_path || path.join(context.entry.projectDir, `${pageId}.html`),
+      };
+      pageRefs.push(ref);
+      pageRefById.set(pageId, ref);
+    }
+    const failedPageInfoById = new Map<string, { title: string; reason: string }>();
+    for (const page of latestPageSnapshot) {
+      if (page.status !== "failed") continue;
+      const pageId = page.page_id || `page-${page.page_number}`;
+      failedPageInfoById.set(pageId, {
+        title: page.title || `第${page.page_number}页`,
+        reason: page.error || "页面仍需修复",
+      });
+    }
+    for (const page of metadataFailedPages) {
+      if (!failedPageInfoById.has(page.pageId)) {
+        failedPageInfoById.set(page.pageId, {
+          title: page.title || page.pageId,
+          reason: page.reason || "页面仍需修复",
+        });
       }
     }
     // Read designContract from the dedicated column
@@ -1277,7 +1503,13 @@ export function setupIPC(mainWindow: BrowserWindow, db: PPTDatabase, agentManage
       outlineTitles = pageRefs.map((ref) => ref.title);
     }
 
-    const outlineItems = outlineTitles.map((title) => ({ title, contentOutline: "" }));
+    const outlineByPageId = new Map(
+      latestPageSnapshot.map((page) => [page.page_id, page.content_outline || ""])
+    );
+    const outlineItems = pageRefs.map((ref) => ({
+      title: ref.title,
+      contentOutline: outlineByPageId.get(ref.pageId) || "",
+    }));
     const pageFileMap = Object.fromEntries(pageRefs.map((p) => [p.pageId, p.htmlPath]));
     const beforeMap = new Map<string, string>();
     const existingPageIdsBeforeRun: string[] = [];
@@ -1293,6 +1525,18 @@ export function setupIPC(mainWindow: BrowserWindow, db: PPTDatabase, agentManage
       existingPageIdsBeforeRun.push(item.pageId);
       beforeMap.set(item.pageId, item.html);
     }
+
+    await db.createGenerationRun({
+      id: context.runId,
+      sessionId: context.sessionId,
+      mode: "edit",
+      totalPages: pageRefs.length,
+      metadata: {
+        editScope: isMainScopeEdit ? "main" : "page",
+        selectedPageId: resolvedSelectedPageId || null,
+        selector: selectedSelector || null,
+      },
+    });
 
     emitGenerateChunk(context.sessionId, {
       type: "stage_started",
@@ -1311,6 +1555,9 @@ export function setupIPC(mainWindow: BrowserWindow, db: PPTDatabase, agentManage
         ? `我准备开始调整「${context.topic}」了。目标：主会话总览壳（index.html），我只会修改切换演示动画与交互层动画。`
         : `我准备开始调整「${context.topic}」了。目标：${resolvedSelectedPageId ? `第 ${resolvedSelectedPageNumber ?? "?"} 页` : "按你的指令智能定位"}${selectedSelector ? `（选择器：${selectedSelector}）` : ""}。`
     );
+    const editTemperature = selectedSelector
+      ? PAGE_EDIT_WITH_SELECTOR_TEMPERATURE
+      : PAGE_EDIT_DEFAULT_TEMPERATURE;
 
     const beforeIndexHtml = fs.existsSync(indexPath)
       ? await fs.promises.readFile(indexPath, "utf-8")
@@ -1322,6 +1569,7 @@ export function setupIPC(mainWindow: BrowserWindow, db: PPTDatabase, agentManage
       apiKey: context.apiKey,
       model: context.model,
       baseUrl: context.providerBaseUrl,
+      temperature: editTemperature,
       styleId: context.styleId,
       styleSkillPrompt: context.styleSkill.prompt,
       topic: context.topic,
@@ -1349,6 +1597,14 @@ export function setupIPC(mainWindow: BrowserWindow, db: PPTDatabase, agentManage
       ? await fs.promises.readFile(indexPath, "utf-8")
       : "";
     const indexChanged = beforeIndexHtml !== afterIndexHtml;
+    if (indexChanged) {
+      const indexValidationErrors = validateProjectIndexHtml(afterIndexHtml);
+      if (indexValidationErrors.length > 0) {
+        const details = indexValidationErrors.join("; ");
+        await db.updateGenerationRunStatus(context.runId, "failed", details);
+        throw new Error(`index.html 验证失败: ${details}`);
+      }
+    }
 
     const pageDescriptors: Array<{ pageNumber: number; title: string; pageId: string; html: string; htmlPath: string }> = [];
     const changedPageDescriptors: Array<{ pageNumber: number; title: string; pageId: string; html: string; htmlPath: string }> = [];
@@ -1401,6 +1657,52 @@ export function setupIPC(mainWindow: BrowserWindow, db: PPTDatabase, agentManage
       });
     }
 
+    const invalidChangedPages = changedPageDescriptors
+      .map((page) => {
+        const validation = validatePersistedPageHtml(page.html, page.pageId);
+        return validation.valid
+          ? null
+          : {
+              page,
+              reason: validation.errors.join("; "),
+            };
+      })
+      .filter((item): item is { page: { pageNumber: number; title: string; pageId: string; html: string; htmlPath: string }; reason: string } =>
+        Boolean(item)
+      );
+    if (invalidChangedPages.length > 0) {
+      const details = invalidChangedPages
+        .map((item) => `${item.page.pageId}（${item.page.title}）：${item.reason}`)
+        .join("；");
+      await db.updateGenerationRunStatus(context.runId, "failed", details);
+      throw new Error(`页面编辑结果验证失败：${details}`);
+    }
+
+    const changedPageIdSet = new Set(changedPageDescriptors.map((page) => page.pageId));
+    for (const page of changedPageDescriptors) {
+      await db.upsertGenerationPage({
+        runId: context.runId,
+        sessionId: context.sessionId,
+        pageId: page.pageId,
+        pageNumber: page.pageNumber,
+        title: page.title,
+        contentOutline: outlineItems.find((_item, index) => pageRefs[index]?.pageId === page.pageId)?.contentOutline || "",
+        htmlPath: page.htmlPath,
+        status: "completed",
+      });
+    }
+
+    const remainingFailedPageInfoById = new Map(failedPageInfoById);
+    for (const pageId of changedPageIdSet) {
+      remainingFailedPageInfoById.delete(pageId);
+    }
+    const generatedPagesForMetadata = pageDescriptors.filter((page) => !remainingFailedPageInfoById.has(page.pageId));
+    const remainingFailedPages = Array.from(remainingFailedPageInfoById.entries()).map(([pageId, info]) => ({
+      pageId,
+      title: info.title || pageRefs.find((ref) => ref.pageId === pageId)?.title || pageId,
+      reason: info.reason || "页面仍需修复",
+    }));
+
     const changedPages = changedPageDescriptors.map((p) => `第${p.pageNumber}页`).join("、");
     const editSummary =
       changedPageDescriptors.length > 0
@@ -1410,11 +1712,41 @@ export function setupIPC(mainWindow: BrowserWindow, db: PPTDatabase, agentManage
         : editSummaryFromEngine.trim() || "我已经检查过了，这次没有检测到需要落盘的页面变化。";
     await emitAssistantMessage(context, editSummary);
 
-    await finalizeGenerationSuccess({
-      context,
+    await db.updateSessionMetadata(context.sessionId, {
+      lastRunId: context.runId,
+      entryMode: "multi_page",
+      generatedPages: generatedPagesForMetadata.map((page) => ({
+        pageNumber: page.pageNumber,
+        title: page.title,
+        pageId: page.pageId,
+        htmlPath: page.htmlPath,
+        html: page.html,
+      })),
+      failedPages: remainingFailedPages,
       indexPath,
-      totalPages: pageRefs.length,
-      generatedPages: pageDescriptors,
+      projectId: context.projectId,
+    });
+    await db.updateProjectStatus(context.projectId, "draft");
+    await db.updateSessionStatus(context.sessionId, remainingFailedPages.length > 0 ? "failed" : "completed");
+    await db.updateGenerationRunStatus(
+      context.runId,
+      remainingFailedPages.length > 0 ? "partial" : "completed",
+      remainingFailedPages.length > 0
+        ? remainingFailedPages.map((page) => `${page.pageId}（${page.title}）：${page.reason}`).join("；")
+        : null
+    );
+    log.info("[generate:start] edit completed", {
+      sessionId: context.sessionId,
+      styleId: context.styleId,
+      changedPages: Array.from(changedPageIdSet),
+      remainingFailedPages: remainingFailedPages.map((page) => page.pageId),
+    });
+    emitGenerateChunk(context.sessionId, {
+      type: "run_completed",
+      payload: {
+        runId: context.runId,
+        totalPages: pageRefs.length,
+      },
     });
   };
 
@@ -1453,6 +1785,18 @@ export function setupIPC(mainWindow: BrowserWindow, db: PPTDatabase, agentManage
     });
     const pageFileMap = Object.fromEntries(pageRefs.map((page) => [page.pageId, page.htmlPath]));
     const indexPath = path.join(context.entry.projectDir, "index.html");
+    await db.createGenerationRun({
+      id: context.runId,
+      sessionId: context.sessionId,
+      mode: "generate",
+      totalPages: pageRefs.length,
+      metadata: {
+        topic: context.topic,
+        styleId: context.styleId,
+        projectDir: context.entry.projectDir,
+        indexPath,
+      },
+    });
 
     emitDeckChunk({
       type: "stage_progress",
@@ -1487,6 +1831,7 @@ export function setupIPC(mainWindow: BrowserWindow, db: PPTDatabase, agentManage
       apiKey: context.apiKey,
       model: context.model,
       baseUrl: context.providerBaseUrl,
+      temperature: PLANNER_TEMPERATURE,
       styleId: context.styleId,
       totalPages: pageRefs.length,
       topic: context.topic,
@@ -1501,6 +1846,7 @@ export function setupIPC(mainWindow: BrowserWindow, db: PPTDatabase, agentManage
         apiKey: context.apiKey,
         model: context.model,
         baseUrl: context.providerBaseUrl,
+        temperature: DESIGN_CONTRACT_TEMPERATURE,
         styleId: context.styleId,
         styleSkillPrompt: context.styleSkill.prompt,
         totalPages: context.totalPages,
@@ -1514,6 +1860,7 @@ export function setupIPC(mainWindow: BrowserWindow, db: PPTDatabase, agentManage
       designContractPromise,
       scaffoldPromise,
     ]);
+    await db.updateSessionDesignContract(context.sessionId, designContract);
     const outlineItems = pageRefs.map((page, index) => {
       const planned = plannedOutlineItems[index];
       return {
@@ -1524,6 +1871,16 @@ export function setupIPC(mainWindow: BrowserWindow, db: PPTDatabase, agentManage
     const outlineTitles = outlineItems.map((item) => item.title);
     for (const page of pageRefs) {
       page.title = outlineTitles[page.pageNumber - 1] || page.title;
+      await db.upsertGenerationPage({
+        runId: context.runId,
+        sessionId: context.sessionId,
+        pageId: page.pageId,
+        pageNumber: page.pageNumber,
+        title: page.title,
+        contentOutline: outlineItems[page.pageNumber - 1]?.contentOutline || "",
+        htmlPath: page.htmlPath,
+        status: "pending",
+      });
     }
 
     await fs.promises.writeFile(
@@ -1570,12 +1927,102 @@ export function setupIPC(mainWindow: BrowserWindow, db: PPTDatabase, agentManage
       beforePageMap.set(item.pageId, item.html);
     }
 
+    const persistedGeneratedPagesById = new Map<string, {
+      pageNumber: number;
+      title: string;
+      pageId: string;
+      htmlPath: string;
+    }>();
+    const persistedFailedPagesById = new Map<string, {
+      pageId: string;
+      title: string;
+      reason: string;
+    }>();
+    const persistGenerationSnapshotMetadata = async () => {
+      await db.updateSessionMetadata(context.sessionId, {
+        lastRunId: context.runId,
+        entryMode: "multi_page",
+        generatedPages: Array.from(persistedGeneratedPagesById.values())
+          .sort((a, b) => a.pageNumber - b.pageNumber),
+        failedPages: Array.from(persistedFailedPagesById.values())
+          .sort((a, b) => {
+            const aNumber = Number(a.pageId.match(/^page-(\d+)$/i)?.[1] || 0);
+            const bNumber = Number(b.pageId.match(/^page-(\d+)$/i)?.[1] || 0);
+            return aNumber - bNumber;
+          }),
+        indexPath,
+        projectId: context.projectId,
+      });
+    };
+    const persistCompletedGeneratedPage = async (page: {
+      pageNumber: number;
+      pageId: string;
+      title: string;
+      contentOutline: string;
+      htmlPath: string;
+    }) => {
+      if (!fs.existsSync(page.htmlPath)) {
+        throw new Error(`${page.pageId}.html 缺失`);
+      }
+      const html = await fs.promises.readFile(page.htmlPath, "utf-8");
+      const validation = validatePersistedPageHtml(html, page.pageId);
+      if (!validation.valid) {
+        throw new Error(`HTML 验证失败 (${page.pageId}): ${validation.errors.join("; ")}`);
+      }
+      await db.upsertGenerationPage({
+        runId: context.runId,
+        sessionId: context.sessionId,
+        pageId: page.pageId,
+        pageNumber: page.pageNumber,
+        title: page.title,
+        contentOutline: page.contentOutline,
+        htmlPath: page.htmlPath,
+        status: "completed",
+      });
+      persistedFailedPagesById.delete(page.pageId);
+      persistedGeneratedPagesById.set(page.pageId, {
+        pageNumber: page.pageNumber,
+        title: page.title,
+        pageId: page.pageId,
+        htmlPath: page.htmlPath,
+      });
+      await persistGenerationSnapshotMetadata();
+    };
+    const persistFailedGeneratedPage = async (page: {
+      pageNumber: number;
+      pageId: string;
+      title: string;
+      contentOutline: string;
+      htmlPath: string;
+      reason: string;
+    }) => {
+      await db.upsertGenerationPage({
+        runId: context.runId,
+        sessionId: context.sessionId,
+        pageId: page.pageId,
+        pageNumber: page.pageNumber,
+        title: page.title,
+        contentOutline: page.contentOutline,
+        htmlPath: page.htmlPath,
+        status: "failed",
+        error: page.reason,
+      });
+      persistedGeneratedPagesById.delete(page.pageId);
+      persistedFailedPagesById.set(page.pageId, {
+        pageId: page.pageId,
+        title: page.title,
+        reason: page.reason,
+      });
+      await persistGenerationSnapshotMetadata();
+    };
+
     const { failedPages } = await runDeepAgentDeckGeneration({
       sessionId: context.sessionId,
       provider: context.provider,
       apiKey: context.apiKey,
       model: context.model,
       baseUrl: context.providerBaseUrl,
+      temperature: PAGE_GENERATION_TEMPERATURE,
       styleId: context.styleId,
       styleSkillPrompt: context.styleSkill.prompt,
       topic: context.topic,
@@ -1589,6 +2036,8 @@ export function setupIPC(mainWindow: BrowserWindow, db: PPTDatabase, agentManage
       pageFileMap,
       agentManager,
       emit: (chunk) => emitDeckChunk(chunk),
+      onPageCompleted: persistCompletedGeneratedPage,
+      onPageFailed: persistFailedGeneratedPage,
       runId: context.runId,
       signal: context.entry.abortController.signal,
     });
@@ -1600,8 +2049,7 @@ export function setupIPC(mainWindow: BrowserWindow, db: PPTDatabase, agentManage
       postValidationErrors.push("index.html 缺失");
     } else {
       const indexHtml = await fs.promises.readFile(indexPath, "utf-8");
-      if (!/<html[\s>]/i.test(indexHtml)) postValidationErrors.push("index.html 缺少 <html> 标签");
-      if (!/<iframe[\s>]/i.test(indexHtml)) postValidationErrors.push("index.html 缺少 iframe 预览壳");
+      postValidationErrors.push(...validateProjectIndexHtml(indexHtml));
     }
     const validationPages = await Promise.all(
       pageRefs.map(async (page) => {
@@ -1613,13 +2061,32 @@ export function setupIPC(mainWindow: BrowserWindow, db: PPTDatabase, agentManage
       })
     );
     for (const item of validationPages) {
+      const pageRef = pageRefs.find((page) => page.pageId === item.pageId);
       if (item.missing) {
-        postValidationErrors.push(`${item.pageId}.html 缺失`);
+        const reason = `${item.pageId}.html 缺失`;
+        postValidationErrors.push(reason);
+        if (!failedPageIdSet.has(item.pageId)) {
+          postValidationFailures.push({
+            pageId: item.pageId,
+            title: pageRef?.title || item.pageId,
+            reason,
+          });
+        }
         continue;
       }
-      if (!/<html[\s>]/i.test(item.html)) postValidationErrors.push(`${item.pageId}.html 缺少 <html>`);
+      if (!/<html[\s>]/i.test(item.html)) {
+        const reason = `${item.pageId}.html 缺少 <html>`;
+        postValidationErrors.push(reason);
+        if (!failedPageIdSet.has(item.pageId)) {
+          postValidationFailures.push({
+            pageId: item.pageId,
+            title: pageRef?.title || item.pageId,
+            reason,
+          });
+        }
+        continue;
+      }
       if (!failedPageIdSet.has(item.pageId)) {
-        const pageRef = pageRefs.find((page) => page.pageId === item.pageId);
         const validation = validatePersistedPageHtml(item.html, item.pageId);
         if (!validation.valid) {
           const reason = validation.errors.join("; ");
@@ -1684,6 +2151,18 @@ export function setupIPC(mainWindow: BrowserWindow, db: PPTDatabase, agentManage
         htmlPath: pageRef.htmlPath,
         html,
       });
+      if (!persistedGeneratedPagesById.has(pageRef.pageId)) {
+        await db.upsertGenerationPage({
+          runId: context.runId,
+          sessionId: context.sessionId,
+          pageId: pageRef.pageId,
+          pageNumber: pageRef.pageNumber,
+          title: pageRef.title,
+          contentOutline: outlineItems[pageRef.pageNumber - 1]?.contentOutline || "",
+          htmlPath: pageRef.htmlPath,
+          status: "completed",
+        });
+      }
       emitDeckChunk({
         type: "page_generated",
         payload: {
@@ -1724,6 +2203,46 @@ export function setupIPC(mainWindow: BrowserWindow, db: PPTDatabase, agentManage
 
     if (failedPages.length > 0) {
       const failedDetails = failedPages.map((item) => `${item.pageId}（${item.title}）：${item.reason}`).join("；");
+      for (const failedPage of failedPages) {
+        const pageRef = pageRefs.find((page) => page.pageId === failedPage.pageId);
+        if (!pageRef) continue;
+        await db.upsertGenerationPage({
+          runId: context.runId,
+          sessionId: context.sessionId,
+          pageId: pageRef.pageId,
+          pageNumber: pageRef.pageNumber,
+          title: pageRef.title,
+          contentOutline: outlineItems[pageRef.pageNumber - 1]?.contentOutline || "",
+          htmlPath: pageRef.htmlPath,
+          status: "failed",
+          error: failedPage.reason,
+        });
+      }
+      await db.updateGenerationRunStatus(
+        context.runId,
+        pageDescriptors.length > 0 ? "partial" : "failed",
+        failedDetails
+      );
+      await db.updateSessionMetadata(context.sessionId, {
+        lastRunId: context.runId,
+        entryMode: "multi_page",
+        generatedPages: pageDescriptors.map((page) => ({
+          pageNumber: page.pageNumber,
+          title: page.title,
+          pageId: page.pageId,
+          htmlPath: page.htmlPath,
+          html: page.html,
+        })),
+        failedPages: failedPages.map((page) => ({
+          pageId: page.pageId,
+          title: page.title,
+          reason: page.reason,
+        })),
+        indexPath,
+        projectId: context.projectId,
+      });
+      await db.updateSessionDesignContract(context.sessionId, designContract);
+      await db.updateProjectStatus(context.projectId, "draft");
       emitDeckChunk({
         type: "llm_status",
         payload: {
@@ -1748,11 +2267,438 @@ export function setupIPC(mainWindow: BrowserWindow, db: PPTDatabase, agentManage
         : `你的创意已经生成完成！共 ${pageDescriptors.length} 页，主题「${context.topic}」。你可以继续在“当前页”精修细节，或在“主会话”调整全局切换动画。`;
     await emitAssistantMessage(context, completionSummary);
 
+    await db.updateGenerationRunStatus(context.runId, "completed", null);
     await finalizeGenerationSuccess({
       context,
       indexPath,
       totalPages: outlineTitles.length,
       generatedPages: pageDescriptors,
+      designContract,
+    });
+  };
+
+  const executeRetryFailedPages = async (context: GenerationContext): Promise<void> => {
+    if (!context.apiKey) {
+      throw new Error(`当前 provider "${context.provider}" 缺少 API Key，请先到设置页配置。`);
+    }
+
+    const indexPath = path.join(context.entry.projectDir, "index.html");
+    let savedDesignContract: DesignContract | undefined;
+    const sessionRecord = (context.session || {}) as Record<string, unknown>;
+    const latestPageSnapshot = await db.listLatestGenerationPageSnapshot(context.sessionId);
+    const incompleteSnapshotRecords = latestPageSnapshot.filter((page) => page.status !== "completed");
+    let metadataGeneratedPageCount = 0;
+    let metadataFailedPages: Array<Record<string, unknown>> = [];
+    if (typeof sessionRecord.metadata === "string" && sessionRecord.metadata.trim().length > 0) {
+      try {
+        const metadata = JSON.parse(sessionRecord.metadata) as {
+          generatedPages?: Array<Record<string, unknown>>;
+          failedPages?: Array<Record<string, unknown>>;
+        };
+        metadataGeneratedPageCount = Array.isArray(metadata.generatedPages) ? metadata.generatedPages.length : 0;
+        metadataFailedPages =
+          incompleteSnapshotRecords.length === 0 && Array.isArray(metadata.failedPages) ? metadata.failedPages : [];
+      } catch {
+        metadataGeneratedPageCount = 0;
+        metadataFailedPages = [];
+      }
+    }
+    if (incompleteSnapshotRecords.length === 0 && metadataFailedPages.length === 0) {
+      throw new Error("当前会话没有可继续生成的页面。");
+    }
+    if (metadataGeneratedPageCount === 0) {
+      const latestSnapshot = await db.listLatestGenerationPageSnapshot(context.sessionId);
+      const completedSnapshotCount = latestSnapshot.filter((page) => page.status === "completed").length;
+      if (completedSnapshotCount === 0) {
+        throw new Error("当前没有成功页面可保留，请使用完整重新生成。");
+      }
+    }
+    if (typeof sessionRecord.designContract === "string" && sessionRecord.designContract.trim().length > 0) {
+      try {
+        savedDesignContract = JSON.parse(sessionRecord.designContract) as DesignContract;
+      } catch {
+        // ignore malformed design contract and rebuild below
+      }
+    }
+    const designContract =
+      savedDesignContract ||
+      await buildDesignContractWithLLM({
+        provider: context.provider,
+        apiKey: context.apiKey,
+        model: context.model,
+        baseUrl: context.providerBaseUrl,
+        temperature: DESIGN_CONTRACT_TEMPERATURE,
+        styleId: context.styleId,
+        styleSkillPrompt: context.styleSkill.prompt,
+        totalPages: context.totalPages,
+        emit: (chunk) => emitGenerateChunk(context.sessionId, chunk),
+        runId: context.runId,
+        signal: context.entry.abortController.signal,
+      });
+
+    const retryPages =
+      incompleteSnapshotRecords.length > 0
+        ? incompleteSnapshotRecords.map((page) => ({
+            pageNumber: page.page_number,
+            pageId: page.page_id,
+            title: page.title || page.page_id,
+            contentOutline: page.content_outline || "",
+            htmlPath: page.html_path || path.join(context.entry.projectDir, `${page.page_id}.html`),
+            retryCount: page.retry_count + 1,
+          }))
+        : metadataFailedPages
+            .map((page, index) => {
+              const rawPageId = typeof page.pageId === "string" ? page.pageId.trim() : "";
+              const inferredNumber = Number(rawPageId.match(/^page-(\d+)$/i)?.[1] || 0);
+              const rawPageNumber = Number(page.pageNumber);
+              const pageNumber =
+                Number.isFinite(rawPageNumber) && rawPageNumber > 0
+                  ? Math.floor(rawPageNumber)
+                  : inferredNumber > 0
+                    ? inferredNumber
+                    : index + 1;
+              const pageId = rawPageId || `page-${pageNumber}`;
+              const title =
+                typeof page.title === "string" && page.title.trim().length > 0
+                  ? page.title.trim()
+                  : `第 ${pageNumber} 页`;
+              const htmlPathRaw = typeof page.htmlPath === "string" ? page.htmlPath.trim() : "";
+              return {
+                pageNumber,
+                pageId,
+                title,
+                contentOutline:
+                  typeof page.contentOutline === "string" ? page.contentOutline.trim() : "",
+                htmlPath: htmlPathRaw
+                  ? path.isAbsolute(htmlPathRaw)
+                    ? htmlPathRaw
+                    : path.join(context.entry.projectDir, htmlPathRaw)
+                  : path.join(context.entry.projectDir, `${pageId}.html`),
+                retryCount: 1,
+              };
+            })
+            .filter((page, index, pages) => pages.findIndex((item) => item.pageId === page.pageId) === index);
+    const pageFileMap = Object.fromEntries(retryPages.map((page) => [page.pageId, page.htmlPath]));
+
+    await db.createGenerationRun({
+      id: context.runId,
+      sessionId: context.sessionId,
+      mode: "retry",
+      totalPages: retryPages.length,
+      metadata: {
+        retryOnly: true,
+        source: incompleteSnapshotRecords.length > 0 ? "latest_incomplete_pages" : "metadata_failed_pages",
+        pageIds: retryPages.map((page) => page.pageId),
+      },
+    });
+    for (const page of retryPages) {
+      await db.upsertGenerationPage({
+        runId: context.runId,
+        sessionId: context.sessionId,
+        pageId: page.pageId,
+        pageNumber: page.pageNumber,
+        title: page.title,
+        contentOutline: page.contentOutline,
+        htmlPath: page.htmlPath,
+        status: "pending",
+        retryCount: page.retryCount,
+      });
+    }
+
+    emitGenerateChunk(context.sessionId, {
+      type: "stage_started",
+      payload: {
+        runId: context.runId,
+        stage: "rendering",
+        label: "正在继续生成未完成页面",
+        progress: 8,
+        totalPages: retryPages.length,
+      },
+    });
+    await emitAssistantMessage(
+      context,
+      `我会继续生成 ${retryPages.length} 个未完成页面：${retryPages.map((page) => page.pageId).join("、")}。`
+    );
+
+    const persistedRetryCompletedPageIds = new Set<string>();
+    const persistedRetryFailedPageIds = new Set<string>();
+
+    const persistCompletedRetryPage = async (page: {
+      pageNumber: number;
+      pageId: string;
+      title: string;
+      contentOutline: string;
+      htmlPath: string;
+    }) => {
+      if (!fs.existsSync(page.htmlPath)) {
+        throw new Error(`${page.pageId}.html 缺失`);
+      }
+      const html = await fs.promises.readFile(page.htmlPath, "utf-8");
+      const validation = validatePersistedPageHtml(html, page.pageId);
+      if (!validation.valid) {
+        throw new Error(`HTML 验证失败 (${page.pageId}): ${validation.errors.join("; ")}`);
+      }
+      const retryPage = retryPages.find((item) => item.pageId === page.pageId);
+      await db.upsertGenerationPage({
+        runId: context.runId,
+        sessionId: context.sessionId,
+        pageId: page.pageId,
+        pageNumber: page.pageNumber,
+        title: page.title,
+        contentOutline: page.contentOutline,
+        htmlPath: page.htmlPath,
+        status: "completed",
+        retryCount: retryPage?.retryCount || 0,
+      });
+      persistedRetryFailedPageIds.delete(page.pageId);
+      persistedRetryCompletedPageIds.add(page.pageId);
+    };
+    const persistFailedRetryPage = async (page: {
+      pageNumber: number;
+      pageId: string;
+      title: string;
+      contentOutline: string;
+      htmlPath: string;
+      reason: string;
+    }) => {
+      const retryPage = retryPages.find((item) => item.pageId === page.pageId);
+      await db.upsertGenerationPage({
+        runId: context.runId,
+        sessionId: context.sessionId,
+        pageId: page.pageId,
+        pageNumber: page.pageNumber,
+        title: page.title,
+        contentOutline: page.contentOutline,
+        htmlPath: page.htmlPath,
+        status: "failed",
+        error: page.reason,
+        retryCount: retryPage?.retryCount || 0,
+      });
+      persistedRetryCompletedPageIds.delete(page.pageId);
+      persistedRetryFailedPageIds.add(page.pageId);
+    };
+
+    const { failedPages } = await runDeepAgentDeckGeneration({
+      sessionId: context.sessionId,
+      provider: context.provider,
+      apiKey: context.apiKey,
+      model: context.model,
+      baseUrl: context.providerBaseUrl,
+      temperature: PAGE_GENERATION_TEMPERATURE,
+      styleId: context.styleId,
+      styleSkillPrompt: context.styleSkill.prompt,
+      topic: context.topic,
+      deckTitle: context.deckTitle,
+      userMessage: context.userMessage || "请继续生成当前会话尚未完成的页面。",
+      outlineTitles: retryPages.map((page) => page.title),
+      outlineItems: retryPages.map((page) => ({ title: page.title, contentOutline: page.contentOutline })),
+      pageTasks: retryPages.map((page) => ({
+        pageNumber: page.pageNumber,
+        pageId: page.pageId,
+        title: page.title,
+        contentOutline: page.contentOutline,
+      })),
+      designContract,
+      projectDir: context.entry.projectDir,
+      indexPath,
+      pageFileMap,
+      agentManager,
+      emit: (chunk) => emitGenerateChunk(context.sessionId, chunk),
+      onPageCompleted: persistCompletedRetryPage,
+      onPageFailed: persistFailedRetryPage,
+      runId: context.runId,
+      signal: context.entry.abortController.signal,
+    });
+
+    const failedPageIdSet = new Set(failedPages.map((page) => page.pageId));
+    const retrySuccessPages: Array<{ pageNumber: number; title: string; pageId: string; htmlPath: string; html: string }> = [];
+    const retryFailures = [...failedPages];
+    for (const page of retryPages) {
+      if (failedPageIdSet.has(page.pageId)) {
+        const failure = failedPages.find((item) => item.pageId === page.pageId);
+        if (!persistedRetryFailedPageIds.has(page.pageId)) {
+          await db.upsertGenerationPage({
+            runId: context.runId,
+            sessionId: context.sessionId,
+            pageId: page.pageId,
+            pageNumber: page.pageNumber,
+            title: page.title,
+            contentOutline: page.contentOutline,
+            htmlPath: page.htmlPath,
+            status: "failed",
+            error: failure?.reason || "页面重试失败",
+            retryCount: page.retryCount,
+          });
+          persistedRetryFailedPageIds.add(page.pageId);
+        }
+        continue;
+      }
+      if (!fs.existsSync(page.htmlPath)) {
+        const reason = `${page.pageId}.html 缺失`;
+        retryFailures.push({ pageId: page.pageId, title: page.title, reason });
+        if (!persistedRetryFailedPageIds.has(page.pageId)) {
+          await db.upsertGenerationPage({
+            runId: context.runId,
+            sessionId: context.sessionId,
+            pageId: page.pageId,
+            pageNumber: page.pageNumber,
+            title: page.title,
+            contentOutline: page.contentOutline,
+            htmlPath: page.htmlPath,
+            status: "failed",
+            error: reason,
+            retryCount: page.retryCount,
+          });
+          persistedRetryFailedPageIds.add(page.pageId);
+        }
+        continue;
+      }
+      const html = await fs.promises.readFile(page.htmlPath, "utf-8");
+      const validation = validatePersistedPageHtml(html, page.pageId);
+      if (!validation.valid) {
+        const reason = validation.errors.join("; ");
+        retryFailures.push({ pageId: page.pageId, title: page.title, reason });
+        if (!persistedRetryFailedPageIds.has(page.pageId)) {
+          await db.upsertGenerationPage({
+            runId: context.runId,
+            sessionId: context.sessionId,
+            pageId: page.pageId,
+            pageNumber: page.pageNumber,
+            title: page.title,
+            contentOutline: page.contentOutline,
+            htmlPath: page.htmlPath,
+            status: "failed",
+            error: reason,
+            retryCount: page.retryCount,
+          });
+          persistedRetryFailedPageIds.add(page.pageId);
+        }
+        continue;
+      }
+      retrySuccessPages.push({
+        pageNumber: page.pageNumber,
+        title: page.title,
+        pageId: page.pageId,
+        htmlPath: page.htmlPath,
+        html,
+      });
+      if (!persistedRetryCompletedPageIds.has(page.pageId)) {
+        await db.upsertGenerationPage({
+          runId: context.runId,
+          sessionId: context.sessionId,
+          pageId: page.pageId,
+          pageNumber: page.pageNumber,
+          title: page.title,
+          contentOutline: page.contentOutline,
+          htmlPath: page.htmlPath,
+          status: "completed",
+          retryCount: page.retryCount,
+        });
+        persistedRetryCompletedPageIds.add(page.pageId);
+      }
+    }
+
+    const retryPageIdSet = new Set(retryPages.map((page) => page.pageId));
+    let previousGeneratedPages: Array<{ pageNumber: number; title: string; pageId: string; htmlPath: string; html: string }> = [];
+    if (context.session?.metadata) {
+      try {
+        const metadata = JSON.parse(context.session.metadata) as {
+          generatedPages?: Array<{ pageNumber: number; title: string; pageId?: string; htmlPath?: string; html?: string }>;
+        };
+        const restoredPages = await Promise.all(
+          (metadata.generatedPages || [])
+            .filter((page) => !retryPageIdSet.has(page.pageId || `page-${page.pageNumber}`))
+            .map(async (page) => {
+              const pageId = page.pageId || `page-${page.pageNumber}`;
+              const htmlPath = page.htmlPath || path.join(context.entry.projectDir, `${pageId}.html`);
+              const html = fs.existsSync(htmlPath)
+                ? await fs.promises.readFile(htmlPath, "utf-8")
+                : page.html || "";
+              if (!html.trim()) return null;
+              return {
+                pageNumber: page.pageNumber,
+                title: page.title,
+                pageId,
+                htmlPath,
+                html,
+              };
+            })
+        );
+        previousGeneratedPages = restoredPages.filter(
+          (page): page is { pageNumber: number; title: string; pageId: string; htmlPath: string; html: string } =>
+            Boolean(page)
+        );
+      } catch {
+        previousGeneratedPages = [];
+      }
+    }
+    const mergedGeneratedPages = [...previousGeneratedPages, ...retrySuccessPages]
+      .sort((a, b) => a.pageNumber - b.pageNumber);
+
+    await db.updateSessionMetadata(context.sessionId, {
+      lastRunId: context.runId,
+      entryMode: "multi_page",
+      generatedPages: mergedGeneratedPages,
+      failedPages: retryFailures.map((page) => ({
+        pageId: page.pageId,
+        title: page.title,
+        reason: page.reason,
+      })),
+      indexPath,
+      projectId: context.projectId,
+    });
+    await db.updateSessionDesignContract(context.sessionId, designContract);
+    await db.updateProjectStatus(context.projectId, "draft");
+
+    if (retryFailures.length > 0) {
+      const failedDetails = retryFailures.map((item) => `${item.pageId}（${item.title}）：${item.reason}`).join("；");
+      await db.updateGenerationRunStatus(
+        context.runId,
+        retrySuccessPages.length > 0 ? "partial" : "failed",
+        failedDetails
+      );
+      emitGenerateChunk(context.sessionId, {
+        type: "llm_status",
+        payload: {
+          runId: context.runId,
+          stage: "rendering",
+          label: "还有几页需要继续修",
+          progress: 90,
+          totalPages: retryPages.length,
+          detail: failedDetails,
+        },
+      });
+      throw new Error(
+        `重试后仍有页面失败（${retryFailures.length}/${retryPages.length}）：${retryFailures
+          .map((item) => `${item.pageId}(${item.title})`)
+          .join(", ")}`
+      );
+    }
+
+    if (mergedGeneratedPages.length < context.totalPages) {
+      const message = `重试页面已完成，但当前只恢复 ${mergedGeneratedPages.length}/${context.totalPages} 页，请继续重试或重新生成。`;
+      await db.updateGenerationRunStatus(context.runId, "partial", message);
+      emitGenerateChunk(context.sessionId, {
+        type: "llm_status",
+        payload: {
+          runId: context.runId,
+          stage: "rendering",
+          label: "还有页面没有恢复",
+          progress: 90,
+          totalPages: retryPages.length,
+          detail: message,
+        },
+      });
+      throw new Error(message);
+    }
+
+    await emitAssistantMessage(context, `失败页面已经重试完成，本次修复 ${retrySuccessPages.length} 页。`);
+    await db.updateGenerationRunStatus(context.runId, "completed", null);
+    await finalizeGenerationSuccess({
+      context,
+      indexPath,
+      totalPages: context.totalPages,
+      generatedPages: mergedGeneratedPages,
       designContract,
     });
   };
@@ -1768,8 +2714,22 @@ export function setupIPC(mainWindow: BrowserWindow, db: PPTDatabase, agentManage
   // ========== Session Management ==========
 
   ipcMain.handle("session:create", async (_event, payload) => {
-    const { topic, styleId, pageCount, provider, apiKey, model, baseUrl } = payload;
+    const { topic, styleId, pageCount } = payload;
     const storagePath = await resolveStoragePath();
+    const settings = await db.getAllSettings();
+    const provider = String(settings.provider || "").trim();
+    if (!provider) {
+      throw new Error("创建会话失败：请先前往系统设置选择 provider。");
+    }
+    const model = String(settings[`model_${provider}`] || "").trim();
+    const baseUrl = String(settings[`base_url_${provider}`] || "").trim();
+    const apiKey = decryptApiKey(settings[`api_key_${provider}`]).trim();
+    if (!model) {
+      throw new Error("创建会话失败：请先前往系统设置填写 model。");
+    }
+    if (!apiKey) {
+      throw new Error("创建会话失败：请先前往系统设置填写 api_key。");
+    }
     const sessionId = crypto.randomUUID();
     const projectDir = path.join(storagePath, sessionId);
 
@@ -1795,7 +2755,7 @@ export function setupIPC(mainWindow: BrowserWindow, db: PPTDatabase, agentManage
 
     await agentManager.createSession({
       sessionId,
-      provider, apiKey, model, baseUrl, projectDir, db, topic, styleId: normalizedStyleId, pageCount,
+      provider, model, baseUrl, projectDir, topic, styleId: normalizedStyleId, pageCount,
     });
 
     return { sessionId };
@@ -1803,7 +2763,15 @@ export function setupIPC(mainWindow: BrowserWindow, db: PPTDatabase, agentManage
 
   ipcMain.handle("session:list", async () => {
     const sessions = await db.listSessions();
-    return sessions.map((session) => normalizeSession(session as unknown as Record<string, unknown>));
+    const enrichedSessions = await Promise.all(
+      sessions.map(async (session) => {
+        const snapshot = await buildSessionGenerationSnapshot(session as unknown as Record<string, unknown>, {
+          includeHtml: false,
+        });
+        return snapshot.session || session as unknown as Record<string, unknown>;
+      })
+    );
+    return enrichedSessions.map((session) => normalizeSession(session as unknown as Record<string, unknown>));
   });
 
   ipcMain.handle("session:get", async (_event, sessionId) => {
@@ -1816,11 +2784,21 @@ export function setupIPC(mainWindow: BrowserWindow, db: PPTDatabase, agentManage
       htmlPath?: string;
       pageId?: string;
       sourceUrl?: string;
+      status?: string;
+      error?: string | null;
     }> = [];
+    const metadataForSnapshot = (() => {
+      if (!session?.metadata) return {} as Record<string, unknown>;
+      try {
+        return JSON.parse(session.metadata) as Record<string, unknown>;
+      } catch {
+        return {} as Record<string, unknown>;
+      }
+    })();
 
     if (session?.metadata) {
       try {
-        const metadata = JSON.parse(session.metadata) as {
+        const metadata = metadataForSnapshot as {
           entryMode?: "single_index" | "multi_page";
           indexPath?: string;
           generatedPages?: Array<{
@@ -1847,6 +2825,7 @@ export function setupIPC(mainWindow: BrowserWindow, db: PPTDatabase, agentManage
                 htmlPath: pagePath,
                 pageId,
                 sourceUrl: getPageSourceUrl(pagePath),
+                status: "completed",
               };
             })
           );
@@ -1879,6 +2858,7 @@ export function setupIPC(mainWindow: BrowserWindow, db: PPTDatabase, agentManage
                 htmlPath: pagePath,
                 pageId,
                 sourceUrl: `${baseUrl}?embed=1#${encodeURIComponent(pageId)}`,
+                status: "completed",
               };
             })
           );
@@ -1895,6 +2875,7 @@ export function setupIPC(mainWindow: BrowserWindow, db: PPTDatabase, agentManage
                 htmlPath: page.htmlPath,
                 pageId: page.pageId || `page-${page.pageNumber}`,
                 sourceUrl: getPageSourceUrl(page.htmlPath),
+                status: "completed",
               };
             })
           );
@@ -1907,10 +2888,53 @@ export function setupIPC(mainWindow: BrowserWindow, db: PPTDatabase, agentManage
       }
     }
 
+    if (session) {
+      const existingPageIds = new Set(generatedPages.map((page) => page.pageId || `page-${page.pageNumber}`));
+      const generationSnapshot = await db.listLatestGenerationPageSnapshot(sessionId);
+      if (generationSnapshot.length > 0) {
+        const project = await db.getProject(sessionId);
+        const metadataIndexPath =
+          typeof metadataForSnapshot.indexPath === "string" && metadataForSnapshot.indexPath.trim().length > 0
+            ? metadataForSnapshot.indexPath.trim()
+            : "";
+        const projectDir =
+          typeof project?.output_path === "string" && project.output_path.trim().length > 0
+            ? project.output_path.trim()
+            : metadataIndexPath
+              ? path.dirname(metadataIndexPath)
+              : path.join(await resolveStoragePath(), sessionId);
+
+        for (const page of generationSnapshot) {
+          const pageId = page.page_id || `page-${page.page_number}`;
+          if (existingPageIds.has(pageId)) continue;
+          const htmlPath = page.html_path || path.join(projectDir, `${pageId}.html`);
+          if (!fs.existsSync(htmlPath)) continue;
+          const html = await fs.promises.readFile(htmlPath, "utf-8");
+          generatedPages.push({
+            pageNumber: page.page_number,
+            title: page.title || `第 ${page.page_number} 页`,
+            html,
+            htmlPath,
+            pageId,
+            sourceUrl: getPageSourceUrl(htmlPath),
+            status: page.status,
+            error: page.error,
+          });
+          existingPageIds.add(pageId);
+        }
+      }
+    }
+    generatedPages.sort((a, b) => a.pageNumber - b.pageNumber);
+
+    const snapshotForGate = await buildSessionGenerationSnapshot(session as unknown as Record<string, unknown> | undefined, {
+      includeHtml: true,
+    });
+    const responsePages = snapshotForGate.pages.length > 0 ? snapshotForGate.pages : generatedPages;
+
     return {
-      session: normalizeSession(session as unknown as Record<string, unknown> | undefined),
+      session: normalizeSession(snapshotForGate.session as unknown as Record<string, unknown> | undefined),
       messages: messages.map((message) => normalizeMessage(message as unknown as Record<string, unknown>)),
-      generatedPages,
+      generatedPages: responsePages,
     };
   });
 
@@ -1968,6 +2992,7 @@ export function setupIPC(mainWindow: BrowserWindow, db: PPTDatabase, agentManage
   // ========== Generation Flow ==========
 
   ipcMain.handle("generate:state", async (_event, rawSessionId: unknown) => {
+    pruneFinishedSessionRunStates();
     const sessionId = typeof rawSessionId === "string" ? rawSessionId.trim() : "";
     if (!sessionId) {
       throw new Error("sessionId 不能为空");
@@ -2014,6 +3039,7 @@ export function setupIPC(mainWindow: BrowserWindow, db: PPTDatabase, agentManage
   });
 
   ipcMain.handle("generate:start", async (event, payload) => {
+    pruneFinishedSessionRunStates();
     const requestedSessionId =
       payload && typeof payload === "object" && typeof (payload as { sessionId?: unknown }).sessionId === "string"
         ? String((payload as { sessionId?: string }).sessionId).trim()
@@ -2039,6 +3065,66 @@ export function setupIPC(mainWindow: BrowserWindow, db: PPTDatabase, agentManage
         totalPages: context.totalPages,
       });
       await executeGeneration(context);
+      return { success: true, runId: context.runId };
+    } catch (error) {
+      if (context) {
+        await finalizeGenerationFailure(context, error);
+      }
+      throw error;
+    } finally {
+      if (context) {
+        agentManager.removeSession(context.sessionId);
+      }
+    }
+  });
+
+  ipcMain.handle("generate:retryFailedPages", async (event, payload) => {
+    pruneFinishedSessionRunStates();
+    const requestedSessionId =
+      payload && typeof payload === "object" && typeof (payload as { sessionId?: unknown }).sessionId === "string"
+        ? String((payload as { sessionId?: string }).sessionId).trim()
+        : "";
+    if (requestedSessionId) {
+      const runningState = sessionRunStates.get(requestedSessionId);
+      if (runningState?.status === "running") {
+        log.info("[generate:retryFailedPages] attach to existing run", {
+          sessionId: requestedSessionId,
+          runId: runningState.runId,
+        });
+        return { success: true, runId: runningState.runId, alreadyRunning: true };
+      }
+    }
+
+    let context: GenerationContext | null = null;
+    try {
+      const retryPayload = payload && typeof payload === "object" ? payload as Record<string, unknown> : {};
+      const retrySupplement =
+        typeof retryPayload.userMessage === "string" && retryPayload.userMessage.trim().length > 0
+          ? retryPayload.userMessage.trim()
+          : "";
+      const retryUserMessage = retrySupplement
+        ? `请继续生成当前会话中未完成页面。\n用户补充说明：${retrySupplement}`
+        : "请继续生成当前会话中未完成页面。";
+      context = await resolveGenerationContext(
+        event,
+        {
+          ...retryPayload,
+          type: "deck",
+          userMessage: retryUserMessage,
+        },
+        { persistUserMessage: false, mode: "retry" }
+      );
+      beginSessionRunState({
+        sessionId: context.sessionId,
+        runId: context.runId,
+        mode: "retry",
+        totalPages: Math.max(
+          1,
+          (await db.listLatestGenerationPageSnapshot(context.sessionId)).filter((page) => page.status !== "completed").length ||
+            context.totalPages
+        ),
+      });
+      await executeRetryFailedPages(context);
       return { success: true, runId: context.runId };
     } catch (error) {
       if (context) {

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react'
 import { Routes, Route, Navigate, useLocation, matchPath } from 'react-router-dom'
 import { Sidebar } from './components/layout/Sidebar'
 import { HomePage } from './pages/home'
@@ -9,10 +10,31 @@ import { StylesPage } from './pages/styles'
 import { StyleEditorPage } from './pages/style-editor'
 import { AppToaster } from './components/AppToaster'
 import { ScrollArea } from './components/ui/ScrollArea'
+import { ipc } from './lib/ipc'
+import { useToastStore } from './store'
 
 function App(): React.JSX.Element {
   const location = useLocation()
   const isSessionDetailRoute = Boolean(matchPath('/sessions/:id/*', location.pathname))
+  const { info } = useToastStore()
+
+  useEffect(() => {
+    const unsubscribe = ipc.onUpdateAvailable((update) => {
+      info(`发现新版本 ${update.latestVersion}`, {
+        description: `当前版本 ${update.currentVersion}，点击前往下载。`,
+        duration: 12000,
+        action: {
+          label: '打开',
+          onClick: () => {
+            window.open(update.releaseUrl, '_blank', 'noopener,noreferrer')
+          }
+        }
+      })
+    })
+    return () => {
+      unsubscribe?.()
+    }
+  }, [info])
 
   if (isSessionDetailRoute) {
     return (

--- a/src/renderer/src/components/preview/PreviewIframe.tsx
+++ b/src/renderer/src/components/preview/PreviewIframe.tsx
@@ -72,7 +72,7 @@ export const PreviewIframe = forwardRef<PreviewIframeHandle, {
 
   // Always preview concrete page file (page-xx.html). index.html is only for external full-deck preview.
   const pageHtmlPath = resolvePageHtmlPath(htmlPath, pageId)
-  const webviewSrc = src ? withPreviewParams(src) : pageHtmlPath ? toFileUrl(pageHtmlPath) : undefined
+  const webviewSrc = pageHtmlPath ? toFileUrl(pageHtmlPath) : src ? withPreviewParams(src) : undefined
   const pointerEnabled = inspectable && inspecting
 
   const handleWebviewRef = useCallback((node: Electron.WebviewTag | null) => {

--- a/src/renderer/src/lib/ipc.ts
+++ b/src/renderer/src/lib/ipc.ts
@@ -1,4 +1,5 @@
 import type { GenerateChunkEvent, GenerateRetryFailedPayload, GenerateStartPayload, UploadedAsset } from '@shared/generation.js'
+import type { UpdateAvailablePayload } from '@shared/app-update.js'
 
 type IpcRendererLike = Window['electron']['ipcRenderer']
 
@@ -168,6 +169,16 @@ export const ipc = {
     getIpc().invoke('file:openInBrowser', { path: filePath, hash, sessionId }) as Promise<{ success: boolean }>,
   saveFile: (payload: { path: string; content: string; sessionId?: string }) =>
     getIpc().invoke('file:save', payload) as Promise<{ success: boolean }>,
-  onGenerateChunk: (callback: (chunk: GenerateChunkEvent) => void) =>
-    getIpc().on('generate:chunk', (_event, chunk) => callback(chunk as GenerateChunkEvent)),
+  onGenerateChunk: (callback: (chunk: GenerateChunkEvent) => void) => {
+    const channel = 'generate:chunk'
+    const handler = (_event: unknown, chunk: unknown) => callback(chunk as GenerateChunkEvent)
+    getIpc().on(channel, handler)
+    return () => getIpc().removeListener(channel, handler)
+  },
+  onUpdateAvailable: (callback: (payload: UpdateAvailablePayload) => void) => {
+    const channel = 'app:update-available'
+    const handler = (_event: unknown, payload: unknown) => callback(payload as UpdateAvailablePayload)
+    getIpc().on(channel, handler)
+    return () => getIpc().removeListener(channel, handler)
+  },
 }

--- a/src/renderer/src/lib/ipc.ts
+++ b/src/renderer/src/lib/ipc.ts
@@ -1,4 +1,4 @@
-import type { GenerateChunkEvent, GenerateStartPayload, UploadedAsset } from '@shared/generation.js'
+import type { GenerateChunkEvent, GenerateRetryFailedPayload, GenerateStartPayload, UploadedAsset } from '@shared/generation.js'
 
 type IpcRendererLike = Window['electron']['ipcRenderer']
 
@@ -78,10 +78,6 @@ export interface CreateSessionPayload {
   topic: string
   styleId: string
   pageCount?: number
-  provider: string
-  apiKey: string
-  model?: string
-  baseUrl?: string
 }
 
 export const ipc = {
@@ -98,6 +94,8 @@ export const ipc = {
         htmlPath?: string
         pageId?: string
         sourceUrl?: string
+        status?: string
+        error?: string | null
       }>
     }>,
   getSessionMessages: (payload: { sessionId: string; chatType: 'main' | 'page'; pageId?: string }) =>
@@ -105,6 +103,8 @@ export const ipc = {
   deleteSession: (sessionId: string) => getIpc().invoke('session:delete', sessionId) as Promise<{ success: boolean }>,
   startGenerate: (payload: GenerateStartPayload) =>
     getIpc().invoke('generate:start', payload) as Promise<{ success: boolean; runId?: string; alreadyRunning?: boolean }>,
+  retryFailedPages: (payload: GenerateRetryFailedPayload) =>
+    getIpc().invoke('generate:retryFailedPages', payload) as Promise<{ success: boolean; runId?: string; alreadyRunning?: boolean }>,
   getGenerateState: (sessionId: string) =>
     getIpc().invoke('generate:state', sessionId) as Promise<GenerateRunStateSnapshot>,
   cancelGenerate: (sessionId: string) => getIpc().invoke('generate:cancel', sessionId) as Promise<{ success: boolean }>,

--- a/src/renderer/src/lib/sessionMetadata.ts
+++ b/src/renderer/src/lib/sessionMetadata.ts
@@ -1,0 +1,50 @@
+type SessionLike = {
+  status?: string | null
+  page_count?: number | null
+  metadata?: string | null
+}
+
+type SessionMetadata = {
+  generatedPages?: unknown[]
+  failedPages?: unknown[]
+}
+
+export interface EditorGate {
+  canEdit: boolean
+  generatedCount: number
+  failedCount: number
+  totalCount: number
+  requiredCount: number
+}
+
+export const parseSessionMetadata = (metadata: string | null | undefined): SessionMetadata => {
+  if (!metadata) return {}
+  try {
+    const parsed = JSON.parse(metadata) as SessionMetadata
+    return parsed && typeof parsed === 'object' ? parsed : {}
+  } catch {
+    return {}
+  }
+}
+
+export const getEditorGate = (session: SessionLike | null | undefined, threshold = 0.5): EditorGate => {
+  const metadata = parseSessionMetadata(session?.metadata)
+  const generatedCount = Array.isArray(metadata.generatedPages) ? metadata.generatedPages.length : 0
+  const failedCount = Array.isArray(metadata.failedPages) ? metadata.failedPages.length : 0
+  const explicitTotal = Number(session?.page_count ?? 0)
+  const totalCount = Math.max(
+    Number.isFinite(explicitTotal) ? Math.floor(explicitTotal) : 0,
+    generatedCount + failedCount,
+    generatedCount
+  )
+  const requiredCount = Math.max(1, Math.ceil(Math.max(1, totalCount) * threshold))
+  const canEdit = generatedCount > 0 && (session?.status === 'completed' || generatedCount >= requiredCount)
+
+  return {
+    canEdit,
+    generatedCount,
+    failedCount,
+    totalCount: Math.max(1, totalCount),
+    requiredCount,
+  }
+}

--- a/src/renderer/src/pages/home.tsx
+++ b/src/renderer/src/pages/home.tsx
@@ -25,7 +25,7 @@ const resolvePageCount = (raw: string): number => {
 export function HomePage() {
   const navigate = useNavigate()
   const { createSession, loading } = useSessionStore()
-  const { settings, fetchSettings, apiKey, model, baseUrl } = useSettingsStore()
+  const { settings, fetchSettings } = useSettingsStore()
   const { success, error, warning } = useToastStore()
   const [topic, setTopic] = useState('')
   const [brief, setBrief] = useState('')
@@ -53,10 +53,10 @@ export function HomePage() {
     const briefText = brief.trim()
     if (!briefText) return '请填写详细描述。'
 
-    const provider = settings?.provider || 'openai'
-    const providerConfig = settings?.providerConfigs?.[provider]
-    const resolvedApiKey = (providerConfig?.apiKey || apiKey).trim()
-    const resolvedModel = (providerConfig?.model || model).trim()
+    const provider = settings?.provider
+    const providerConfig = provider ? settings?.providerConfigs?.[provider] : undefined
+    const resolvedApiKey = (providerConfig?.apiKey || '').trim()
+    const resolvedModel = (providerConfig?.model || '').trim()
     const resolvedStoragePath = (settings?.storagePath || '').trim()
     if (!resolvedApiKey || !resolvedModel || !resolvedStoragePath) return SETTINGS_REQUIRED_MESSAGE
 
@@ -110,20 +110,11 @@ export function HomePage() {
     const safePageCount = Number.parseInt(pageCount.trim(), 10)
     const initialPrompt = briefText || `请围绕"${topicText || '未命名主题'}"生成一份 ${safePageCount} 页、风格为 ${selectedStyle.label} 的演示稿。`
 
-    const provider = settings?.provider || 'openai'
-    const providerConfig = settings?.providerConfigs?.[provider]
-    const resolvedApiKey = (providerConfig?.apiKey || apiKey).trim()
-    const resolvedModel = (providerConfig?.model || model).trim() || undefined
-    const resolvedBaseUrl = (providerConfig?.baseUrl || baseUrl).trim() || undefined
     try {
       const sessionId = await createSession({
         topic: topicText,
         styleId: selectedStyleId,
         pageCount: safePageCount,
-        provider,
-        apiKey: resolvedApiKey,
-        model: resolvedModel,
-        baseUrl: resolvedBaseUrl,
       })
       success('会话创建成功', {
         description: `已开始生成创意`,

--- a/src/renderer/src/pages/session-detail.tsx
+++ b/src/renderer/src/pages/session-detail.tsx
@@ -40,6 +40,7 @@ import {
 import { useSessionStore, useGenerateStore } from '../store'
 import type { GenerateChunkEvent, UploadedAsset } from '@shared/generation.js'
 import { useToastStore } from '../store'
+import { getEditorGate } from '../lib/sessionMetadata'
 
 export function SessionDetailPage() {
   const { id } = useParams<{ id: string }>()
@@ -109,6 +110,12 @@ export function SessionDetailPage() {
     setElementText('')
   }, [selectedPage?.pageId])
 
+  const isFullyGenerated = useMemo(() => {
+    if (!currentSession) return false
+    const gate = getEditorGate(currentSession)
+    return gate.generatedCount >= gate.totalCount && gate.failedCount === 0
+  }, [currentSession])
+
   useEffect(() => {
     if (!inspecting) return
     const onKeyDown = (event: KeyboardEvent) => {
@@ -132,6 +139,13 @@ export function SessionDetailPage() {
   useEffect(() => {
     useGenerateStore.getState().setPages(currentGeneratedPages)
   }, [currentGeneratedPages])
+
+  useEffect(() => {
+    if (!id || !currentSession) return
+    if (!isFullyGenerated) {
+      navigate(`/sessions/${id}/generating`, { replace: true })
+    }
+  }, [currentSession, id, isFullyGenerated, navigate])
 
   useEffect(() => {
     if (!id) return
@@ -222,7 +236,9 @@ export function SessionDetailPage() {
             html: payload.html,
             htmlPath: payload.htmlPath,
             pageId: payload.pageId || `page-${payload.pageNumber}`,
-            sourceUrl: payload.sourceUrl
+            sourceUrl: payload.sourceUrl,
+            status: 'completed',
+            error: null
           })
           setSelectedPageNumber(payload.pageNumber)
           setPreviewKey((k) => k + 1)
@@ -230,7 +246,14 @@ export function SessionDetailPage() {
       } else if (type === 'page_updated') {
         useGenerateStore
           .getState()
-          .updatePage(payload.pageId || `page-${payload.pageNumber}`, payload.html)
+          .updatePage(payload.pageId || `page-${payload.pageNumber}`, payload.html, {
+            pageNumber: payload.pageNumber,
+            title: payload.title,
+            htmlPath: payload.htmlPath,
+            sourceUrl: payload.sourceUrl,
+            status: 'completed',
+            error: null
+          })
         setSelectedPageNumber(payload.pageNumber)
         setPreviewKey((k) => k + 1)
       } else if (type === 'assistant_message') {
@@ -553,8 +576,8 @@ export function SessionDetailPage() {
         </header>
 
         <div className="flex min-h-0 flex-1">
-          <aside className="flex min-h-0 w-[220px] shrink-0 flex-col border-r border-[#d9cdb9]/70 bg-[#f4eddf]/78 px-3 pb-4 pt-3">
-            <div className="mb-4 flex items-center justify-between px-1">
+          <aside className="flex min-h-0 w-[220px] shrink-0 flex-col border-r border-[#d9cdb9]/70 bg-[#f4eddf]/78 px-2.5 pb-3 pt-3">
+            <div className="mb-3 flex items-center justify-between rounded-lg border border-[#d8cab0]/65 bg-[#fbf4e8]/66 px-2 py-1.5">
               <Tooltip>
                 <TooltipTrigger asChild>
                   <button
@@ -572,68 +595,74 @@ export function SessionDetailPage() {
                 Pages · {normalizedOrderedPages.length}
               </div>
             </div>
-            <ScrollArea className="min-h-0 flex-1" viewportClassName="space-y-2 pr-1.5">
+            <ScrollArea className="min-h-0 flex-1" viewportClassName="px-0.5 pb-2">
               {normalizedOrderedPages.length === 0 ? (
                 <div className="flex min-h-[96px] items-center justify-center rounded-lg border border-[#d8ccb5]/65 bg-[#f8f0e2]/70 text-xs text-muted-foreground">
                   暂无页面
                 </div>
               ) : (
-                normalizedOrderedPages.map((page) => {
-                  const isSelected = selectedPage?.pageNumber === page.pageNumber
-                  return (
-                    <Tooltip key={page.pageNumber}>
-                      <TooltipTrigger asChild>
-                        <button
-                          type="button"
-                          onClick={() => setSelectedPageNumber(page.pageNumber)}
-                          className={cn(
-                            'group w-full min-w-0 rounded-lg border p-1.5 text-left transition-all duration-200 cursor-pointer',
-                            isSelected
-                              ? 'border-[#9ab47d]/85 bg-[#edf4e3]/88 shadow-[0_8px_18px_rgba(103,126,74,0.18)]'
-                              : 'border-transparent bg-transparent hover:border-[#d6c8ae]/70 hover:bg-[#eee3d0]/68'
-                          )}
-                        >
-                          <div
+                <div className="space-y-2">
+                  {normalizedOrderedPages.map((page) => {
+                    const isSelected = selectedPage?.pageNumber === page.pageNumber
+                    return (
+                      <Tooltip key={page.pageNumber}>
+                        <TooltipTrigger asChild>
+                          <button
+                            type="button"
+                            onClick={() => setSelectedPageNumber(page.pageNumber)}
                             className={cn(
-                              'aspect-video overflow-hidden rounded-md border bg-[#fffaf1]/70',
-                              isSelected ? 'border-[#89a96c]/70' : 'border-[#d8ccb6]/55'
+                              'group block w-full min-w-0 overflow-hidden rounded-lg border p-1.5 text-left transition-all duration-200 cursor-pointer',
+                              isSelected
+                                ? 'border-[#99b27c]/90 bg-[#edf4e3]/88 shadow-[0_8px_18px_rgba(103,126,74,0.16)]'
+                                : 'border-[#ddd1bd]/45 bg-[#f7efdf]/36 hover:border-[#d6c8ae]/75 hover:bg-[#eee3d0]/68'
                             )}
                           >
-                            <PreviewIframe
-                              key={`thumb-${page.pageId}-${previewKey}`}
-                              src={page.sourceUrl}
-                              htmlPath={page.htmlPath}
-                              pageId={page.pageId}
-                              title={`filmstrip-page-${page.pageNumber}`}
-                              inspectable={false}
-                            />
-                          </div>
-                          <div className="mt-1.5 flex items-center justify-between gap-1 px-0.5">
-                            <span className="text-[10px] font-semibold uppercase tracking-[0.08em] text-[#5c6c47]">
-                              P{page.pageNumber}
-                            </span>
-                            {isSelected ? (
-                              <span className="rounded-full bg-[#7f9b5f] px-1.5 py-0.5 text-[9px] font-semibold text-white">
-                                当前
+                            <div
+                              className={cn(
+                                'h-[106px] w-full overflow-hidden rounded-md border bg-[#fffaf1]/72',
+                                isSelected ? 'border-[#89a96c]/72' : 'border-[#d8ccb6]/58'
+                              )}
+                              style={{ contain: 'paint' }}
+                            >
+                              <PreviewIframe
+                                key={`thumb-${page.pageId}-${previewKey}`}
+                                src={page.sourceUrl}
+                                htmlPath={page.htmlPath}
+                                pageId={page.pageId}
+                                title={`filmstrip-page-${page.pageNumber}`}
+                                inspectable={false}
+                              />
+                            </div>
+                            <div className="mt-1.5 flex items-center justify-between gap-1 px-0.5">
+                              <span className="text-[10px] font-semibold uppercase tracking-[0.08em] text-[#5c6c47]">
+                                P{page.pageNumber}
                               </span>
-                            ) : null}
+                              {isSelected ? (
+                                <span className="rounded-full bg-[#7f9b5f] px-1.5 py-0.5 text-[9px] font-semibold text-white">
+                                  当前
+                                </span>
+                              ) : null}
+                            </div>
+                            <div
+                              className="mt-0.5 block w-full min-w-0 max-w-full overflow-hidden whitespace-normal break-words px-0.5 text-[11px] font-medium leading-4 text-[#4c5d3d]"
+                              style={{ display: '-webkit-box', WebkitLineClamp: 2, WebkitBoxOrient: 'vertical' }}
+                            >
+                              {page.title}
+                            </div>
+                          </button>
+                        </TooltipTrigger>
+                        <TooltipContent side="right" align="start">
+                          <div className="max-w-[240px]">
+                            <div className="text-[10px] font-semibold uppercase tracking-[0.12em] text-[#7a875f]">
+                              Page {page.pageNumber}
+                            </div>
+                            <div className="mt-0.5 text-sm font-medium text-[#3e4a32]">{page.title}</div>
                           </div>
-                          <div className="mt-0.5 block w-full min-w-0 overflow-hidden text-ellipsis whitespace-nowrap px-0.5 text-[11px] font-medium text-[#4c5d3d]">
-                            {page.title}
-                          </div>
-                        </button>
-                      </TooltipTrigger>
-                      <TooltipContent side="right" align="start">
-                        <div className="max-w-[240px]">
-                          <div className="text-[10px] font-semibold uppercase tracking-[0.12em] text-[#7a875f]">
-                            Page {page.pageNumber}
-                          </div>
-                          <div className="mt-0.5 text-sm font-medium text-[#3e4a32]">{page.title}</div>
-                        </div>
-                      </TooltipContent>
-                    </Tooltip>
-                  )
-                })
+                        </TooltipContent>
+                      </Tooltip>
+                    )
+                  })}
+                </div>
               )}
             </ScrollArea>
           </aside>
@@ -668,6 +697,11 @@ export function SessionDetailPage() {
                       <Crosshair className="mr-2 h-4 w-4" />
                       {inspecting ? '退出检选' : '检选元素'}
                     </Button>
+                  )}
+                  {selectedPage.status === 'failed' && (
+                    <div className="absolute bottom-3 left-3 z-20 max-w-[520px] rounded-lg border border-[#d7b5ae]/75 bg-[#fff4ef]/88 px-3 py-2 text-xs text-[#8e5a53] shadow-sm backdrop-blur-sm">
+                      这一页上次生成失败，当前展示的是可恢复的页面文件。请保持“当前页”上下文，直接描述如何修复或重新生成这一页。
+                    </div>
                   )}
                   {inspecting && (
                     <div className="pointer-events-none absolute left-1/2 top-3 -translate-x-1/2 rounded-lg border border-[#98b8ea]/55 bg-[#eff5ff]/85 px-3 py-1.5 text-xs text-[#375f97] shadow-sm backdrop-blur-sm">

--- a/src/renderer/src/pages/session-generating.tsx
+++ b/src/renderer/src/pages/session-generating.tsx
@@ -7,10 +7,12 @@ import { Button } from '../components/ui/Button'
 import { ScrollArea } from '../components/ui/ScrollArea'
 import videoSrc from '../assets/images/video.mp4'
 import dayjs from 'dayjs'
+import { getEditorGate, type EditorGate } from '../lib/sessionMetadata'
 
 type LocationState = {
   initialPrompt?: string
   retry?: boolean
+  rerunToken?: number
 }
 
 const STAGE_LABELS: Record<string, string> = {
@@ -25,6 +27,15 @@ const NOISY_REPEATED_PATTERNS = [
   /^验证完成状态/,
   /^当前页面已填充/,
 ]
+
+const extractFailedPages = (message: string | null): string[] => {
+  if (!message) return []
+  const matches = Array.from(message.matchAll(/page-\d+\([^)]+\)/g))
+  return matches.map((match) => match[0]).slice(0, 12)
+}
+
+const isSessionFullyGenerated = (gate: EditorGate) =>
+  gate.generatedCount >= gate.totalCount && gate.failedCount === 0
 
 export function SessionGeneratingPage() {
   const { id } = useParams<{ id: string }>()
@@ -46,6 +57,7 @@ export function SessionGeneratingPage() {
   const [sessionTitle, setSessionTitle] = useState<string>('当前会话')
   const [, setTotalPages] = useState<number>(1)
   const [panelCollapsed, setPanelCollapsed] = useState(false)
+  const [editorGate, setEditorGate] = useState<EditorGate>(() => getEditorGate(null))
 
   const appendEvent = (line: string, timestamp?: string) => {
     setEvents((prev) => {
@@ -86,7 +98,8 @@ export function SessionGeneratingPage() {
     const initialPrompt =
       state?.initialPrompt?.trim() ||
       '请生成一份结构清晰、可直接预览的演示文稿初稿。'
-    if (state?.retry) {
+    const explicitRerun = typeof state?.rerunToken === 'number'
+    if (state?.retry || explicitRerun) {
       startedSessionRef.current = null
       activeRunIdRef.current = null
       terminalStatusRef.current = null
@@ -164,22 +177,32 @@ export function SessionGeneratingPage() {
         setStatus('failed')
         setError(event.payload.message)
         appendEvent('生成失败，请点击重试或返回会话列表。', event.payload.timestamp)
+        void ipc.getSession(id).then(({ session }) => {
+          if (!active) return
+          setEditorGate(getEditorGate(session as { status?: string; page_count?: number | null; metadata?: string | null } | null))
+        }).catch(() => {})
       }
     }
 
     const unsubscribe = ipc.onGenerateChunk((event) => applyChunk(event))
 
     const startRun = () => {
-      if (startedSessionRef.current === id) return
-      startedSessionRef.current = id
+      const runKey = `${id}:${state?.retry ? 'retry' : 'generate'}:${state?.rerunToken ?? 'initial'}`
+      if (startedSessionRef.current === runKey) return
+      startedSessionRef.current = runKey
       setStatus('running')
       setError(null)
       terminalStatusRef.current = null
       if (import.meta.env.DEV) {
-        console.info('[generate:start] request', { sessionId: id, hasInitialPrompt: Boolean(initialPrompt) })
+        console.info('[generate:start] request', { sessionId: id, retry: Boolean(state?.retry), hasInitialPrompt: Boolean(initialPrompt) })
       }
-      void ipc
-        .startGenerate({ sessionId: id, userMessage: initialPrompt, type: 'deck' })
+      const request = state?.retry
+        ? ipc.retryFailedPages({
+            sessionId: id,
+            userMessage: state.initialPrompt?.trim() || undefined
+          })
+        : ipc.startGenerate({ sessionId: id, userMessage: initialPrompt, type: 'deck' })
+      void request
         .then((result) => {
           if (result?.runId) {
             activeRunIdRef.current = result.runId
@@ -206,6 +229,10 @@ export function SessionGeneratingPage() {
           appendEvent('生成失败，请点击重试或返回会话列表。', new Date().toISOString())
           setStatus('failed')
           setError(message)
+          void ipc.getSession(id).then(({ session }) => {
+            if (!active) return
+            setEditorGate(getEditorGate(session as { status?: string; page_count?: number | null; metadata?: string | null } | null))
+          }).catch(() => {})
         })
     }
 
@@ -216,8 +243,10 @@ export function SessionGeneratingPage() {
       ])
       .then(([{ session }, runState]) => {
         if (!active) return
-        const snapshot = (session || {}) as { status?: string; title?: string | null; page_count?: number | null }
+        const snapshot = (session || {}) as { status?: string; title?: string | null; page_count?: number | null; metadata?: string | null }
         const currentStatus = snapshot.status || 'active'
+        const snapshotGate = getEditorGate(snapshot)
+        setEditorGate(snapshotGate)
         if (snapshot.title && snapshot.title.trim().length > 0) {
           setSessionTitle(snapshot.title)
         }
@@ -226,32 +255,34 @@ export function SessionGeneratingPage() {
         }
 
         if (runState) {
+          const shouldHydrateFromSnapshot = !state?.retry || runState.hasActiveRun
+
           if (runState.hasActiveRun && runState.runId) {
             activeRunIdRef.current = runState.runId
           }
-          if (typeof runState.totalPages === 'number' && runState.totalPages > 0) {
+          if (shouldHydrateFromSnapshot && typeof runState.totalPages === 'number' && runState.totalPages > 0) {
             setTotalPages((prev) => Math.max(prev, Math.floor(runState.totalPages)))
           }
-          if (typeof runState.progress === 'number' && runState.progress > 0) {
+          if (shouldHydrateFromSnapshot && typeof runState.progress === 'number' && runState.progress > 0) {
             const safeProgress =
               runState.status === 'completed'
                 ? Math.min(100, Math.floor(runState.progress))
                 : Math.min(90, Math.floor(runState.progress))
             setProgress((prev) => Math.max(prev, safeProgress))
           }
-          if (runState.status === 'failed' && runState.error) {
+          if (shouldHydrateFromSnapshot && runState.status === 'failed' && runState.error) {
             setError(runState.error)
           }
-          if (!state?.retry && Array.isArray(runState.events) && runState.events.length > 0) {
+          if (shouldHydrateFromSnapshot && Array.isArray(runState.events) && runState.events.length > 0) {
             for (const event of runState.events) {
               applyChunk(event, { replay: true })
             }
           }
-          if (runState.status === 'completed' && !state?.retry) {
+          if (runState.status === 'completed' && !state?.retry && !explicitRerun) {
             navigate(`/sessions/${id}`, { replace: true })
             return
           }
-          if (runState.status === 'failed' && !state?.retry) {
+          if (runState.status === 'failed' && !state?.retry && !explicitRerun) {
             setStatus('failed')
             setError(runState.error || '该会话上一次生成失败，你可以直接重试。')
             appendEvent('检测到该会话未成功完成，保留在生成页以便继续处理。', new Date().toISOString())
@@ -264,11 +295,33 @@ export function SessionGeneratingPage() {
           }
         }
 
-        if (currentStatus === 'completed' && !state?.retry) {
+        const hasManualStartIntent = Boolean(
+          state?.retry ||
+          explicitRerun ||
+          (state?.initialPrompt && state.initialPrompt.trim().length > 0)
+        )
+        const fullyGenerated = isSessionFullyGenerated(snapshotGate)
+
+        if (fullyGenerated && !state?.retry && !explicitRerun) {
           navigate(`/sessions/${id}`, { replace: true })
           return
         }
-        if (currentStatus === 'failed' && !state?.retry) {
+        if (currentStatus === 'completed' && !state?.retry && !explicitRerun) {
+          navigate(`/sessions/${id}`, { replace: true })
+          return
+        }
+        if (!fullyGenerated && !hasManualStartIntent) {
+          setStatus('failed')
+          if (snapshotGate.generatedCount > 0) {
+            setError(`会话尚未完成：已完成 ${snapshotGate.generatedCount}/${snapshotGate.totalCount} 页。请选择继续生成剩余页。`)
+            appendEvent('检测到会话部分完成。请继续生成剩余页。', new Date().toISOString())
+          } else {
+            setError(`会话尚未完成：当前 0/${snapshotGate.totalCount} 页。请重新生成。`)
+            appendEvent('检测到会话尚未产出有效页面。请重新生成。', new Date().toISOString())
+          }
+          return
+        }
+        if (currentStatus === 'failed' && !state?.retry && !explicitRerun && !hasManualStartIntent) {
           setStatus('failed')
           setError('该会话上一次生成失败，你可以直接重试。')
           appendEvent('检测到该会话未成功完成，保留在生成页以便继续处理。', new Date().toISOString())
@@ -284,9 +337,12 @@ export function SessionGeneratingPage() {
       active = false
       unsubscribe?.()
     }
-  }, [id, navigate, location.key, state?.initialPrompt, state?.retry])
+  }, [id, navigate, location.key, state?.initialPrompt, state?.retry, state?.rerunToken])
 
   const displayProgress = Math.max(0, Math.min(100, Math.round(progress)))
+  const failedPages = extractFailedPages(error)
+  const fullyGenerated = isSessionFullyGenerated(editorGate)
+  const hasGeneratedPages = editorGate.generatedCount > 0
 
   return (
     <div className="relative flex h-full flex-col overflow-hidden bg-[linear-gradient(165deg,#d8edf8_0%,#cce6ee_38%,#e9e3d1_100%)]">
@@ -420,7 +476,33 @@ export function SessionGeneratingPage() {
           {status === 'failed' && (
             <div className="mt-2 rounded-lg border border-[#d7b5ae] bg-[#fbf1ee] px-4 py-3 text-sm text-[#93564f]">
               <div>{error || '生成失败，请重试。'}</div>
+              {failedPages.length > 0 && (
+                <div className="mt-2 flex flex-wrap gap-1.5">
+                  {failedPages.map((page) => (
+                    <span
+                      key={page}
+                      className="rounded-md border border-[#d7b5ae]/70 bg-[#fff8f4]/75 px-2 py-1 text-xs text-[#8e5a53]"
+                    >
+                      {page}
+                    </span>
+                  ))}
+                </div>
+              )}
               <div className="mt-3 flex items-center gap-2">
+                {!fullyGenerated && hasGeneratedPages && (
+                  <Button
+                    size="sm"
+                    onClick={() => navigate(`/sessions/${id}/generating`, {
+                      replace: true,
+                      state: {
+                        retry: true,
+                        rerunToken: Date.now(),
+                      },
+                    })}
+                  >
+                    继续生成剩余页
+                  </Button>
+                )}
                 <Button
                   size="sm"
                   variant="outline"
@@ -428,18 +510,21 @@ export function SessionGeneratingPage() {
                 >
                   返回会话列表
                 </Button>
-                <Button
-                  size="sm"
-                  onClick={() => navigate(`/sessions/${id}/generating`, {
-                    replace: true,
-                    state: {
-                      initialPrompt: state?.initialPrompt,
-                      retry: true,
-                    },
-                  })}
-                >
-                  立即重试
-                </Button>
+                {!hasGeneratedPages && (
+                  <Button
+                    size="sm"
+                    onClick={() => navigate(`/sessions/${id}/generating`, {
+                      replace: true,
+                      state: {
+                        initialPrompt: state?.initialPrompt,
+                        retry: false,
+                        rerunToken: Date.now(),
+                      },
+                    })}
+                  >
+                    重新生成
+                  </Button>
+                )}
               </div>
             </div>
           )}

--- a/src/renderer/src/pages/sessions.tsx
+++ b/src/renderer/src/pages/sessions.tsx
@@ -2,8 +2,9 @@ import { useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { Button } from '../components/ui/Button'
 import { Card, CardContent, CardHeader, CardTitle } from '../components/ui/Card'
-import { FolderOpen, Trash2, Clock, MessageSquare, RotateCcw } from 'lucide-react'
+import { FolderOpen, Trash2, MessageSquare } from 'lucide-react'
 import { useSessionStore } from '../store'
+import { getEditorGate } from '../lib/sessionMetadata'
 
 export function SessionsPage() {
   const navigate = useNavigate()
@@ -14,24 +15,13 @@ export function SessionsPage() {
   }, [fetchSessions])
 
   const sortedSessions = [...sessions].sort((a, b) => b.updated_at - a.updated_at)
-  const statusLabel = (status: string) => {
-    if (status === 'failed') return '失败'
-    if (status === 'completed') return '完成'
-    if (status === 'active') return '生成中'
-    return status
+  const isFullyGenerated = (session: { status: string; metadata: string | null; page_count: number | null }) => {
+    const gate = getEditorGate(session)
+    return session.status === 'completed' || (gate.generatedCount >= gate.totalCount && gate.failedCount === 0)
   }
-  const getSessionRoute = (session: { id: string; status: string }) =>
-    session.status === 'completed' ? `/sessions/${session.id}` : `/sessions/${session.id}/generating`
 
-  const buildRetryPrompt = (session: { topic: string | null; page_count: number | null; styleId: string | null }) => {
-    const topic = (session.topic || '').trim()
-    const pageCount = session.page_count || 5
-    const styleId = session.styleId || 'minimal-white'
-    if (topic) {
-      return `请围绕“${topic}”重新生成一份 ${pageCount} 页演示稿，风格为 ${styleId}。请从头构建并输出完整可预览页面。`
-    }
-    return `请重新生成当前会话内容，输出 ${pageCount} 页演示稿，风格为 ${styleId}，并确保页面可直接预览。`
-  }
+  const getSessionRoute = (session: { id: string; status: string; metadata: string | null; page_count: number | null }) =>
+    isFullyGenerated(session) ? `/sessions/${session.id}` : `/sessions/${session.id}/generating`
 
   return (
     <div className="mx-auto w-full max-w-6xl p-6">
@@ -57,34 +47,25 @@ export function SessionsPage() {
         </Card>
       ) : (
         <div className="grid gap-3">
-          {sortedSessions.map((session) => (
-            <Card
-              key={session.id}
-              className="cursor-pointer transition-all hover:translate-y-[-1px] hover:shadow-[0_14px_28px_rgba(90,72,52,0.16)]"
-              onClick={() => navigate(getSessionRoute(session))}
-            >
+          {sortedSessions.map((session) => {
+            const isComplete = isFullyGenerated(session)
+            const editorGate = getEditorGate(session)
+            const statusText = isComplete ? '已完成' : editorGate.failedCount > 0 ? '已失败' : '进行中'
+            const statusClassName = isComplete
+              ? 'border-[#bad8b7]/80 bg-[#eef9ec] text-[#4a7a46]'
+              : editorGate.failedCount > 0
+                ? 'border-[#d7b5ae]/70 bg-[#fbf1ee] text-[#93564f]'
+                : 'border-[#e1d1b7]/80 bg-[#fff7e8]/75 text-[#7c6a4c]'
+            return (
+              <Card
+                key={session.id}
+                className="cursor-pointer transition-all hover:translate-y-[-1px] hover:shadow-[0_14px_28px_rgba(90,72,52,0.16)]"
+                onClick={() => navigate(getSessionRoute(session))}
+              >
               <CardHeader className="pb-2">
                 <div className="flex items-start justify-between">
                   <CardTitle className="truncate text-base">{session.title}</CardTitle>
                   <div className="flex items-center gap-1">
-                    {session.status === 'failed' && (
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        onClick={(e) => {
-                          e.stopPropagation()
-                          navigate(`/sessions/${session.id}/generating`, {
-                            state: {
-                              initialPrompt: buildRetryPrompt(session),
-                              retry: true,
-                            },
-                          })
-                        }}
-                      >
-                        <RotateCcw className="mr-1 h-3.5 w-3.5" />
-                        重新生成
-                      </Button>
-                    )}
                     <Button
                       variant="ghost"
                       size="sm"
@@ -99,25 +80,22 @@ export function SessionsPage() {
                 </div>
               </CardHeader>
               <CardContent>
-                <div className="flex flex-wrap items-center gap-3 text-xs text-muted-foreground">
+                <div className="flex items-center gap-2 text-xs text-muted-foreground">
                   <span className="soft-pill inline-flex items-center gap-1 rounded-lg px-3 py-1 text-secondary-foreground">
                     <MessageSquare className="h-3 w-3" />
-                    {session.status === 'completed' ? '进入会话' : '继续生成'}
+                    {isComplete ? '进入会话' : '进入生成页'}
                   </span>
-                  <span>{session.topic || '无主题'}</span>
-                  <span>•</span>
-                  <span>{session.page_count || '?'} 页</span>
-                  <span>•</span>
-                  <span className="flex items-center gap-1">
-                    <Clock className="h-3 w-3" />
-                    {new Date(session.updated_at * 1000).toLocaleString()}
+                  <span className={`rounded-lg border px-2 py-1 ${statusClassName}`}>
+                    {statusText}
                   </span>
-                  <span>•</span>
-                  <span>{statusLabel(session.status)}</span>
+                  <span className="rounded-lg border border-[#e1d1b7]/80 bg-[#fff7e8]/75 px-2 py-1 text-[#7c6a4c]">
+                    {editorGate.generatedCount}/{editorGate.totalCount} 页
+                  </span>
                 </div>
               </CardContent>
             </Card>
-          ))}
+            )
+          })}
         </div>
       )}
     </div>

--- a/src/renderer/src/pages/sessions.tsx
+++ b/src/renderer/src/pages/sessions.tsx
@@ -50,12 +50,15 @@ export function SessionsPage() {
           {sortedSessions.map((session) => {
             const isComplete = isFullyGenerated(session)
             const editorGate = getEditorGate(session)
-            const statusText = isComplete ? '已完成' : editorGate.failedCount > 0 ? '已失败' : '进行中'
+            const hasCompletedPages = editorGate.generatedCount > 0
+            const isContinuable = !isComplete && hasCompletedPages
+            const statusText = isComplete ? '已完成' : isContinuable ? '可继续生成' : '需重新生成'
+            const actionText = isComplete ? '进入会话' : isContinuable ? '继续生成' : '重新生成'
             const statusClassName = isComplete
               ? 'border-[#bad8b7]/80 bg-[#eef9ec] text-[#4a7a46]'
-              : editorGate.failedCount > 0
-                ? 'border-[#d7b5ae]/70 bg-[#fbf1ee] text-[#93564f]'
-                : 'border-[#e1d1b7]/80 bg-[#fff7e8]/75 text-[#7c6a4c]'
+              : isContinuable
+                ? 'border-[#d6c08d]/80 bg-[#fff3cf] text-[#7a5a19] shadow-[0_0_0_1px_rgba(214,192,141,0.14)]'
+                : 'border-[#d7b5ae]/70 bg-[#fbf1ee] text-[#93564f]'
             return (
               <Card
                 key={session.id}
@@ -83,14 +86,19 @@ export function SessionsPage() {
                 <div className="flex items-center gap-2 text-xs text-muted-foreground">
                   <span className="soft-pill inline-flex items-center gap-1 rounded-lg px-3 py-1 text-secondary-foreground">
                     <MessageSquare className="h-3 w-3" />
-                    {isComplete ? '进入会话' : '进入生成页'}
+                    {actionText}
                   </span>
-                  <span className={`rounded-lg border px-2 py-1 ${statusClassName}`}>
+                  <span className={`rounded-lg border px-2 py-1 font-semibold ${statusClassName}`}>
                     {statusText}
                   </span>
                   <span className="rounded-lg border border-[#e1d1b7]/80 bg-[#fff7e8]/75 px-2 py-1 text-[#7c6a4c]">
                     {editorGate.generatedCount}/{editorGate.totalCount} 页
                   </span>
+                  {!isComplete && editorGate.failedCount > 0 && (
+                    <span className="rounded-lg border border-[#d7b5ae]/70 bg-[#fff7f2]/80 px-2 py-1 text-[#93564f]">
+                      失败 {editorGate.failedCount}
+                    </span>
+                  )}
                 </div>
               </CardContent>
             </Card>

--- a/src/renderer/src/store/generateStore.ts
+++ b/src/renderer/src/store/generateStore.ts
@@ -14,15 +14,26 @@ interface GenerateStore {
   status: GenerateRunStatus
   isGenerating: boolean
   progress: GenerateProgress | null
-  currentPages: { pageNumber: number; title: string; html: string; htmlPath?: string; pageId?: string; sourceUrl?: string }[]
+  currentPages: { pageNumber: number; title: string; html: string; htmlPath?: string; pageId?: string; sourceUrl?: string; status?: string; error?: string | null }[]
   error: string | null
   cancelReason: string | null
 
   startGeneration: () => void
   updateProgress: (progress: Partial<GenerateProgress>) => void
-  setPages: (pages: { pageNumber: number; title: string; html: string; htmlPath?: string; pageId?: string; sourceUrl?: string }[]) => void
-  addPage: (page: { pageNumber: number; title: string; html: string; htmlPath?: string; pageId?: string; sourceUrl?: string }) => void
-  updatePage: (pageId: string, html: string) => void
+  setPages: (pages: { pageNumber: number; title: string; html: string; htmlPath?: string; pageId?: string; sourceUrl?: string; status?: string; error?: string | null }[]) => void
+  addPage: (page: { pageNumber: number; title: string; html: string; htmlPath?: string; pageId?: string; sourceUrl?: string; status?: string; error?: string | null }) => void
+  updatePage: (
+    pageId: string,
+    html: string,
+    patch?: Partial<{
+      pageNumber: number
+      title: string
+      htmlPath?: string
+      sourceUrl?: string
+      status?: string
+      error?: string | null
+    }>
+  ) => void
   finishGeneration: () => void
   cancelGeneration: (reason?: string) => void
   setError: (error: string | null) => void
@@ -56,9 +67,9 @@ export const useGenerateStore = create<GenerateStore>((set) => ({
     currentPages: [...state.currentPages, page]
   })),
 
-  updatePage: (pageId, html) => set((state) => ({
+  updatePage: (pageId, html, patch) => set((state) => ({
     currentPages: state.currentPages.map((page) =>
-      page.pageId === pageId ? { ...page, html } : page
+      page.pageId === pageId ? { ...page, ...patch, html } : page
     )
   })),
 

--- a/src/renderer/src/store/sessionStore.ts
+++ b/src/renderer/src/store/sessionStore.ts
@@ -38,6 +38,8 @@ export interface GeneratedPage {
   htmlPath?: string
   pageId?: string
   sourceUrl?: string
+  status?: string
+  error?: string | null
 }
 
 interface SessionStore {
@@ -53,10 +55,6 @@ interface SessionStore {
     topic: string
     styleId: string
     pageCount?: number
-    provider: string
-    apiKey: string
-    model?: string
-    baseUrl?: string
   }) => Promise<string>
   loadSession: (sessionId: string) => Promise<void>
   loadMessages: (payload: { sessionId: string; chatType: 'main' | 'page'; pageId?: string }) => Promise<void>

--- a/src/shared/app-update.ts
+++ b/src/shared/app-update.ts
@@ -1,0 +1,7 @@
+export interface UpdateAvailablePayload {
+  currentVersion: string
+  latestVersion: string
+  releaseUrl: string
+  releaseName?: string
+  publishedAt?: string
+}

--- a/src/shared/generation.ts
+++ b/src/shared/generation.ts
@@ -24,6 +24,11 @@ export interface GenerateStartPayload {
   docPaths?: string[]
 }
 
+export interface GenerateRetryFailedPayload {
+  sessionId: string
+  userMessage?: string
+}
+
 export interface GeneratedPagePayload {
   pageNumber: number
   title: string


### PR DESCRIPTION
- Added update notifications: the app checks GitHub Releases on startup and lets users open the release page when a newer version is available.
- Improved generation recovery: progress can be restored from completed pages after an unexpected app exit.
- Improved failure handling: fully failed sessions prompt regeneration, while partially completed sessions can continue remaining pages.
- Improved retry flow: only unfinished pages are retried, and user retry notes are preserved.
- Improved edit stability: page structure is validated before marking edits as completed.
- Unified model settings: generation and editing now always use the latest model configuration from Settings.
- Improved model stability: outline planning and JSON output parsing are more tolerant of malformed local/weak-model responses.
