### PR TITLE
feat: add optional web search integration

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -8,11 +8,13 @@ import { AgentManager } from './agent'
 import { setupIPC } from './ipc'
 import { setStyleDb } from './utils/style-skills'
 import type { UpdateAvailablePayload } from '@shared/app-update'
+import { stopManagedWebSearchService } from './utils/web-search-service'
 
 let mainWindow: BrowserWindow | null = null
 let db: PPTDatabase | null = null
 let agentManager: AgentManager | null = null
 let isShuttingDown = false
+let isStoppingWebSearchService = false
 
 const APP_NAME = 'OhMyPPT'
 const DEFAULT_WINDOW_WIDTH = 1100
@@ -284,16 +286,36 @@ app.on('window-all-closed', () => {
   if (process.platform !== 'darwin') app.quit()
 })
 
-app.on('before-quit', () => {
+app.on('before-quit', (event) => {
+  if (isStoppingWebSearchService) {
+    return
+  }
   if (isShuttingDown) return
   isShuttingDown = true
-  if (db) {
-    void db.close().catch((error) => {
-      log.warn('[app] failed to close database on before-quit', {
+  isStoppingWebSearchService = true
+  event.preventDefault()
+
+  void (async () => {
+    try {
+      await stopManagedWebSearchService()
+    } catch (error) {
+      log.warn('[app] failed to stop managed websearch service on before-quit', {
         message: error instanceof Error ? error.message : String(error),
       })
-    })
-  }
+    }
+
+    if (db) {
+      try {
+        await db.close()
+      } catch (error) {
+        log.warn('[app] failed to close database on before-quit', {
+          message: error instanceof Error ? error.message : String(error),
+        })
+      }
+    }
+
+    app.quit()
+  })()
 })
 
 export { mainWindow, db, agentManager }

--- a/src/main/ipc/generate.ts
+++ b/src/main/ipc/generate.ts
@@ -690,6 +690,9 @@ export const runDeepAgentDeckGeneration = async (args: {
   modelTimeoutMs?: number
   topic: string
   deckTitle: string
+  allowWebSearch?: boolean
+  webSearchEngines?: string[]
+  webSearchLimit?: number
   userMessage: string
   outlineTitles: string[]
   outlineItems: OutlineItem[]
@@ -937,6 +940,9 @@ export const runDeepAgentDeckGeneration = async (args: {
         topic: args.topic,
         deckTitle: args.deckTitle,
         styleId: args.styleId,
+        allowWebSearch: args.allowWebSearch,
+        webSearchEngines: args.webSearchEngines,
+        webSearchLimit: args.webSearchLimit,
         styleSkillPrompt: args.styleSkillPrompt,
         appLocale: args.appLocale,
         designContract: args.designContract,
@@ -971,6 +977,7 @@ export const runDeepAgentDeckGeneration = async (args: {
                 pageTitle: page.title,
                 pageOutline: page.outline,
                 layoutIntent: page.layoutIntent,
+                allowWebSearch: args.allowWebSearch,
                 sourceDocumentPaths: args.sourceDocumentPaths,
                 referenceDocumentSnippets,
                 isRetryMode: args.generationMode === 'retry',
@@ -1257,6 +1264,9 @@ export const runDeepAgentEdit = async (args: {
   modelTimeoutMs?: number
   topic: string
   deckTitle: string
+  allowWebSearch?: boolean
+  webSearchEngines?: string[]
+  webSearchLimit?: number
   userMessage: string
   outlineTitles: string[]
   outlineItems: OutlineItem[]
@@ -1292,6 +1302,9 @@ export const runDeepAgentEdit = async (args: {
       topic: args.topic,
       deckTitle: args.deckTitle,
       styleId: args.styleId,
+      allowWebSearch: args.allowWebSearch,
+      webSearchEngines: args.webSearchEngines,
+      webSearchLimit: args.webSearchLimit,
       styleSkillPrompt: args.styleSkillPrompt,
       appLocale: args.appLocale,
       designContract: args.designContract,

--- a/src/main/ipc/generation-flow.ts
+++ b/src/main/ipc/generation-flow.ts
@@ -64,6 +64,9 @@ export type GenerationContext = {
   topic: string
   deckTitle: string
   appLocale: 'zh' | 'en'
+  allowWebSearch: boolean
+  webSearchEngines: string[]
+  webSearchLimit: number
 }
 
 type FinalizeGenerationArgs = {
@@ -200,6 +203,16 @@ export function createGenerationService(ctx: IpcContext): GenerationService {
     const session = await db.getSession(sessionId)
     if (!session) throw new Error('Session not found')
     const sessionRecord = session as unknown as Record<string, unknown>
+    const sessionMetadata =
+      typeof sessionRecord.metadata === 'string' && sessionRecord.metadata.trim().length > 0
+        ? (() => {
+            try {
+              return JSON.parse(sessionRecord.metadata) as Record<string, unknown>
+            } catch {
+              return {}
+            }
+          })()
+        : {}
     const previousSessionStatus = String(sessionRecord.status || 'active')
     const styleCatalog = listStyleCatalog()
     const defaultStyleId =
@@ -280,6 +293,17 @@ export function createGenerationService(ctx: IpcContext): GenerationService {
 
     const settings = await db.getAllSettings()
     const appLocale = settings.locale === 'en' ? 'en' : 'zh'
+    const allowWebSearch = sessionMetadata.allowWebSearch === true
+    const webSearchEngines = Array.isArray(settings.web_search_engines)
+      ? settings.web_search_engines
+          .map((item) => String(item || '').trim().toLowerCase())
+          .filter((item) => item.length > 0)
+      : ['bing', 'duckduckgo']
+    const rawWebSearchLimit = Number(settings.web_search_limit)
+    const webSearchLimit =
+      Number.isFinite(rawWebSearchLimit) && rawWebSearchLimit > 0
+        ? Math.max(1, Math.min(20, Math.round(rawWebSearchLimit)))
+        : 20
     const activeModel = await resolveActiveModelConfig(ctx)
     const modelTimeouts = await resolveGlobalModelTimeouts(ctx)
     const { provider, model, apiKey } = activeModel
@@ -378,7 +402,10 @@ export function createGenerationService(ctx: IpcContext): GenerationService {
       sourceDocumentPaths,
       topic,
       deckTitle,
-      appLocale
+      appLocale,
+      allowWebSearch,
+      webSearchEngines,
+      webSearchLimit
     }
   }
 
@@ -689,6 +716,9 @@ export function createGenerationService(ctx: IpcContext): GenerationService {
       appLocale: context.appLocale,
       topic: context.topic,
       deckTitle: context.deckTitle,
+      allowWebSearch: context.allowWebSearch,
+      webSearchEngines: context.webSearchEngines,
+      webSearchLimit: context.webSearchLimit,
       userMessage: context.userMessage,
       outlineTitles,
       outlineItems,
@@ -1227,6 +1257,9 @@ export function createGenerationService(ctx: IpcContext): GenerationService {
       appLocale: context.appLocale,
       topic: context.topic,
       deckTitle: context.deckTitle,
+      allowWebSearch: context.allowWebSearch,
+      webSearchEngines: context.webSearchEngines,
+      webSearchLimit: context.webSearchLimit,
       userMessage: context.userMessage,
       outlineTitles,
       outlineItems,
@@ -1762,6 +1795,9 @@ export function createGenerationService(ctx: IpcContext): GenerationService {
       appLocale: context.appLocale,
       topic: context.topic,
       deckTitle: context.deckTitle,
+      allowWebSearch: context.allowWebSearch,
+      webSearchEngines: context.webSearchEngines,
+      webSearchLimit: context.webSearchLimit,
       userMessage:
         context.userMessage ||
         'Continue generating the unfinished slides in this session. Determine the content language from the existing topic, outline, and source materials; do not infer it from this instruction.',

--- a/src/main/ipc/session-handlers.ts
+++ b/src/main/ipc/session-handlers.ts
@@ -23,6 +23,7 @@ export function registerSessionHandlers(ctx: IpcContext): void {
 
   ipcMain.handle('session:create', async (_event, payload) => {
     const { topic, styleId, pageCount } = payload
+    const allowWebSearch = payload?.allowWebSearch === true
     const referenceDocumentPath =
       typeof payload?.referenceDocumentPath === 'string' ? payload.referenceDocumentPath.trim() : ''
     const locale = await readAppLocale(ctx)
@@ -114,6 +115,10 @@ export function registerSessionHandlers(ctx: IpcContext): void {
       styleId: normalizedStyleId,
       pageCount,
       referenceDocumentPath: sessionReferenceDocumentPath
+    })
+
+    await db.updateSessionMetadata(sessionId, {
+      allowWebSearch
     })
 
     return { sessionId }

--- a/src/main/ipc/settings-handlers.ts
+++ b/src/main/ipc/settings-handlers.ts
@@ -7,6 +7,15 @@ import {
   type ConfigurableModelTimeoutProfile,
   resolveModelTimeoutMs
 } from '@shared/model-timeout'
+import {
+  DEFAULT_WEB_SEARCH_ENGINES,
+  DEFAULT_WEB_SEARCH_LIMIT,
+  DEFAULT_WEB_SEARCH_PROXY_URL,
+  SUPPORTED_WEB_SEARCH_ENGINES,
+  getWebSearchServiceStatus,
+  installWebSearchService,
+  startWebSearchService
+} from '../utils/web-search-service'
 import { readAppLocale, uiText } from './locale-utils'
 
 const readGlobalTimeouts = (
@@ -32,11 +41,38 @@ export function registerSettingsHandlers(ctx: IpcContext): void {
       typeof settings.storage_path === 'string' && settings.storage_path.trim().length > 0
         ? settings.storage_path.trim()
         : ''
+    const webSearchEngines = Array.isArray(settings.web_search_engines)
+      ? settings.web_search_engines
+          .map((item) => String(item || '').trim().toLowerCase())
+          .filter((item) =>
+            SUPPORTED_WEB_SEARCH_ENGINES.includes(
+              item as (typeof SUPPORTED_WEB_SEARCH_ENGINES)[number]
+            )
+          )
+      : DEFAULT_WEB_SEARCH_ENGINES
+    const rawWebSearchLimit = Number(settings.web_search_limit)
+    const webSearchLimit =
+      Number.isFinite(rawWebSearchLimit) && rawWebSearchLimit > 0
+        ? Math.max(1, Math.min(20, Math.round(rawWebSearchLimit)))
+        : DEFAULT_WEB_SEARCH_LIMIT
+    const webSearchUseProxy = settings.web_search_use_proxy === true
+    const webSearchProxyUrl =
+      typeof settings.web_search_proxy_url === 'string' &&
+      settings.web_search_proxy_url.trim().length > 0
+        ? settings.web_search_proxy_url.trim()
+        : DEFAULT_WEB_SEARCH_PROXY_URL
     return {
       theme: settings.theme || 'light',
       locale: settings.locale === 'en' ? 'en' : 'zh',
       storagePath,
-      timeouts: readGlobalTimeouts(settings)
+      timeouts: readGlobalTimeouts(settings),
+      webSearch: {
+        engines: webSearchEngines.length > 0 ? webSearchEngines : DEFAULT_WEB_SEARCH_ENGINES,
+        limit: webSearchLimit,
+        useProxy: webSearchUseProxy,
+        proxyUrl: webSearchProxyUrl,
+        serviceStatus: await getWebSearchServiceStatus()
+      }
     }
   })
 
@@ -65,6 +101,41 @@ export function registerSettingsHandlers(ctx: IpcContext): void {
     if (typeof settings.storagePath === 'string' && settings.storagePath.trim().length > 0) {
       await db.setStoragePath(settings.storagePath)
     }
+    if (settings.webSearch && typeof settings.webSearch === 'object') {
+      const webSearch = settings.webSearch as {
+        engines?: unknown
+        limit?: unknown
+        useProxy?: unknown
+        proxyUrl?: unknown
+      }
+      if (Array.isArray(webSearch.engines)) {
+        const engines = webSearch.engines
+          .map((item) => String(item || '').trim().toLowerCase())
+          .filter((item) =>
+            SUPPORTED_WEB_SEARCH_ENGINES.includes(
+              item as (typeof SUPPORTED_WEB_SEARCH_ENGINES)[number]
+            )
+          )
+        await db.setSetting(
+          'web_search_engines',
+          engines.length > 0 ? engines : DEFAULT_WEB_SEARCH_ENGINES
+        )
+      }
+      if (webSearch.limit !== undefined) {
+        const rawLimit = Number(webSearch.limit)
+        const limit =
+          Number.isFinite(rawLimit) && rawLimit > 0
+            ? Math.max(1, Math.min(20, Math.round(rawLimit)))
+            : DEFAULT_WEB_SEARCH_LIMIT
+        await db.setSetting('web_search_limit', limit)
+      }
+      if (webSearch.useProxy !== undefined) {
+        await db.setSetting('web_search_use_proxy', webSearch.useProxy === true)
+      }
+      if (typeof webSearch.proxyUrl === 'string') {
+        await db.setSetting('web_search_proxy_url', webSearch.proxyUrl.trim())
+      }
+    }
     if (settings.timeouts && typeof settings.timeouts === 'object') {
       const timeouts = settings.timeouts as Partial<
         Record<ConfigurableModelTimeoutProfile, unknown>
@@ -77,6 +148,29 @@ export function registerSettingsHandlers(ctx: IpcContext): void {
       }
     }
     return { success: true }
+  })
+
+  ipcMain.handle('settings:getWebSearchServiceStatus', async () => {
+    log.info('[settings:getWebSearchServiceStatus] requested')
+    return getWebSearchServiceStatus()
+  })
+
+  ipcMain.handle('settings:installWebSearchService', async () => {
+    log.info('[settings:installWebSearchService] requested')
+    return installWebSearchService()
+  })
+
+  ipcMain.handle('settings:startWebSearchService', async () => {
+    log.info('[settings:startWebSearchService] requested')
+    const settings = await db.getAllSettings()
+    return startWebSearchService({
+      useProxy: settings.web_search_use_proxy === true,
+      proxyUrl:
+        typeof settings.web_search_proxy_url === 'string' &&
+        settings.web_search_proxy_url.trim().length > 0
+          ? settings.web_search_proxy_url.trim()
+          : DEFAULT_WEB_SEARCH_PROXY_URL
+    })
   })
 
   ipcMain.handle('settings:upsertModelConfig', async (_event, payload) => {

--- a/src/main/prompt/deck-system.ts
+++ b/src/main/prompt/deck-system.ts
@@ -6,6 +6,7 @@ import {
   FRONTEND_CAPABILITIES,
   PAGE_SEMANTIC_STRUCTURE,
   buildOutlinePageList,
+  formatCurrentDate,
   formatDesignContract,
   resolveStylePrompt,
 } from "./shared";
@@ -17,7 +18,34 @@ export function buildDeckAgentSystemPrompt(
   const { presetLabel, presetId, stylePrompt: resolvedStylePrompt } = resolveStylePrompt(styleId);
   const stylePrompt = context.styleSkillPrompt?.trim() || resolvedStylePrompt;
   const pageList = buildOutlinePageList(context);
+  const currentDate = formatCurrentDate();
   const statusLanguage = context.appLocale === "en" ? "English" : "Simplified Chinese";
+  const searchEnabled = context.allowWebSearch === true;
+  const currentDateBlock = searchEnabled
+    ? [
+        "## Current date",
+        `- ${currentDate}`,
+        "- Web search is enabled for this session.",
+        "- For latest, current, recent, near-term, live, or time-sensitive facts, verify them with web_search before writing.",
+        "- Use the current date and current year as the default time anchor unless the user explicitly requests historical information.",
+        "- When the topic is broad, search broadly first, then narrow based on first-round findings.",
+      ]
+    : [
+        "## Current date",
+        `- ${currentDate}`,
+        "- Web search is not enabled for this session.",
+        "- Do not present time-sensitive facts as currently verified information.",
+      ];
+  const searchExecutionBlock = searchEnabled
+    ? [
+        "3. Before writing time-sensitive facts, call web_search.",
+        "   For latest/current/recent topics, avoid defaulting to stale years or months unless the user explicitly requests history.",
+        "   If search snippets are insufficient for concrete facts or numbers, call fetch_web_content on 1-3 high-value results before finalizing the slide.",
+      ]
+    : [
+        "3. Web search is disabled in this session.",
+        "   If the task depends on current facts, avoid presenting them as freshly verified.",
+      ];
 
   const targetInfo = context.selectedPageId
     ? `This run may only modify: ${context.selectedPageId}`
@@ -71,6 +99,8 @@ export function buildDeckAgentSystemPrompt(
     formatDesignContract(context.designContract),
     ...sourceDocumentInstructions,
     "",
+    ...currentDateBlock,
+    "",
     CANVAS_CONSTRAINTS,
     "- index.html 是总览壳（导航+iframe），不要修改其核心结构。",
     "",
@@ -100,9 +130,10 @@ export function buildDeckAgentSystemPrompt(
     "   progress must be a numeric literal such as 10, 35, or 88. Do not pass strings such as \"10\".",
     "   Progress must be detailed and monotonic. Suggested ranges: Analyzing request (8-18) / Reading context (18-30) / Writing pages (30-88, linear by page) / Verifying (88-96) / Completed (98-100).",
     "   Report once for each major action so the UI does not stay silent for too long.",
-    step3Instruction,
-    "4. verify_completion() — check whether target pages are filled",
-    "5. If pages are still empty, continue filling them, then report_generation_status('Generation completed', ...)",
+    ...searchExecutionBlock,
+    step3Instruction.replace(/^3\./, "4."),
+    "5. verify_completion() — check whether target pages are filled",
+    "6. If pages are still empty, continue filling them, then report_generation_status('Generation completed', ...)",
     "## Current Task",
     `Topic: ${context.topic}`,
     `Deck title: ${context.deckTitle}`,

--- a/src/main/prompt/edit-system.ts
+++ b/src/main/prompt/edit-system.ts
@@ -7,6 +7,7 @@ import {
   FRONTEND_CAPABILITIES,
   PAGE_SEMANTIC_STRUCTURE,
   buildOutlinePageList,
+  formatCurrentDate,
   formatDesignContract,
   resolveStylePrompt
 } from './shared'
@@ -18,9 +19,33 @@ export function buildEditAgentSystemPrompt(
   const { presetLabel, presetId, stylePrompt: resolvedStylePrompt } = resolveStylePrompt(styleId)
   const stylePrompt = context.styleSkillPrompt?.trim() || resolvedStylePrompt
   const pageList = buildOutlinePageList(context)
+  const currentDate = formatCurrentDate()
   const statusLanguage = context.appLocale === 'en' ? 'English' : 'Simplified Chinese'
   const analyzingEditRequestLabel = progressText(context.appLocale, 'understanding')
   const editCompletedLabel = progressText(context.appLocale, 'completed')
+  const searchEnabled = context.allowWebSearch === true
+  const currentDateBlock = searchEnabled
+    ? [
+        '## Current date',
+        `- ${currentDate}`,
+        '- Web search is enabled for this session.',
+        '- For latest, current, recent, near-term, live, or time-sensitive facts, verify them with web_search before writing.'
+      ]
+    : [
+        '## Current date',
+        `- ${currentDate}`,
+        '- Web search is not enabled for this session.',
+        '- Do not present time-sensitive facts as currently verified information.'
+      ]
+  const searchExecutionBlock = searchEnabled
+    ? [
+        '3. Before writing time-sensitive facts, call web_search.',
+        '   If search snippets are insufficient for concrete facts or numbers, call fetch_web_content on 1-3 high-value results before finalizing the edit.'
+      ]
+    : [
+        '3. Web search is disabled in this session.',
+        '   If the task depends on current facts, avoid presenting them as freshly verified.'
+      ]
 
   const targetInfo = context.selectedPageId
     ? `Target page: ${context.selectedPageId} (slide ${context.selectedPageNumber ?? '?'})`
@@ -87,6 +112,8 @@ export function buildEditAgentSystemPrompt(
       context.designContract ? '\n设计契约（本次演示的实际视觉规范）：' : '',
       context.designContract ? formatDesignContract(context.designContract) : '',
       '',
+      ...currentDateBlock,
+      '',
       '## Current Task',
       `Topic: ${context.topic}`,
       `Deck title: ${context.deckTitle}`,
@@ -135,6 +162,8 @@ export function buildEditAgentSystemPrompt(
     context.designContract ? '\n设计契约（本次演示的实际视觉规范，修改时必须遵守）：' : '',
     context.designContract ? formatDesignContract(context.designContract) : '',
     '',
+    ...currentDateBlock,
+    '',
     CANVAS_CONSTRAINTS,
     '',
     PAGE_SEMANTIC_STRUCTURE,
@@ -181,17 +210,18 @@ export function buildEditAgentSystemPrompt(
     '   progress must be a numeric literal such as 10, 42, or 95. Do not pass strings such as "10".',
     '   Progress must be monotonic and granular: Analyze (10-25) / Locate target (25-40) / Apply edit (40-88) / Verify (88-96) / Completed (98-100).',
     '   Do not jump straight to 90+. Advance with meaningful steps.',
+    ...searchExecutionBlock,
     hasSelector
-      ? '3. read_file target page + grep to locate target → edit_file(old_string, new_string) for precise replacement'
+      ? '4. read_file target page + grep to locate target → edit_file(old_string, new_string) for precise replacement'
       : '',
     !hasSelector
       ? isSinglePageEdit
-        ? '3. Call update_single_page_file(pageId=target page, content). Single-page edits must not call update_page_file.'
-        : '3. Call update_page_file(pageId, content) to apply edits. Always pass pageId explicitly.'
+        ? '4. Call update_single_page_file(pageId=target page, content). Single-page edits must not call update_page_file.'
+        : '4. Call update_page_file(pageId, content) to apply edits. Always pass pageId explicitly.'
       : '',
-    '4. verify_completion() — confirm the target page file structure is complete',
-    `5. report_generation_status('${editCompletedLabel}', ...)`,
-    "6. Final response: summarize the change in 1-2 sentences. Use the same language as the user's edit instruction unless the user explicitly requests another language.",
+    '5. verify_completion() — confirm the target page file structure is complete',
+    `6. report_generation_status('${editCompletedLabel}', ...)`,
+    "7. Final response: summarize the change in 1-2 sentences. Use the same language as the user's edit instruction unless the user explicitly requests another language.",
     '## Current Task',
     `Topic: ${context.topic}`,
     `Deck title: ${context.deckTitle}`,

--- a/src/main/prompt/generation-user.ts
+++ b/src/main/prompt/generation-user.ts
@@ -5,6 +5,7 @@ import {
   FRONTEND_CAPABILITIES,
   PAGE_SEMANTIC_STRUCTURE,
   buildOutlinePageList,
+  formatCurrentDate,
   formatDesignContract,
 } from "./shared";
 
@@ -39,6 +40,7 @@ export function buildSinglePageGenerationPrompt(args: {
   pageTitle: string;
   pageOutline: string;
   layoutIntent?: SessionDeckGenerationContext["outlineItems"][number]["layoutIntent"];
+  allowWebSearch?: boolean;
   sourceDocumentPaths?: string[];
   referenceDocumentSnippets?: string;
   isRetryMode?: boolean;
@@ -49,6 +51,7 @@ export function buildSinglePageGenerationPrompt(args: {
     previousError: string;
   };
 }): string {
+  const currentDate = formatCurrentDate();
   const retryInstructions = args.retryContext
     ? [
         "",
@@ -91,6 +94,17 @@ export function buildSinglePageGenerationPrompt(args: {
             "- Do not expand only from the outline. Do not invent exact numbers, dates, system names, or status claims not present in the source document.",
           ].filter(Boolean)
       : [];
+  const webSearchInstructions = args.allowWebSearch
+    ? [
+        "",
+        `Current date: ${currentDate}`,
+        "Web search is enabled for this session.",
+        "- For latest, current, recent, near-term, live, news, release, benchmark, ranking, price, version, or other time-sensitive facts, do not write from stale memory first.",
+        "- Search first, then write. Use current date and current year as the default time anchor unless the user explicitly requests historical information.",
+        "- If the page topic is still broad, start with a broad search to understand the current landscape before narrowing to specific entities.",
+        "- If search snippets are not enough to support concrete facts or numbers, call fetch_web_content to inspect the page details before finalizing the slide.",
+      ]
+    : [];
   return [
     "Generate and write only this slide. Do not modify other slides.",
     "",
@@ -100,6 +114,7 @@ export function buildSinglePageGenerationPrompt(args: {
     `Slide title: ${args.pageTitle}`,
     `Content points: ${args.pageOutline || "Expand from the topic with moderate information density."}`,
     args.layoutIntent ? formatLayoutIntentPrompt(args.layoutIntent) : "",
+    ...webSearchInstructions,
     ...sourceDocumentInstructions,
     "",
     CONTENT_LANGUAGE_RULES,

--- a/src/main/prompt/planning.ts
+++ b/src/main/prompt/planning.ts
@@ -1,10 +1,17 @@
-import { CONTENT_LANGUAGE_RULES } from "./shared";
+import { CONTENT_LANGUAGE_RULES, formatCurrentDate } from "./shared";
 
 export function buildPlanningSystemPrompt(totalPages: number = 0): string {
+  const currentDate = formatCurrentDate();
   return [
     "You are a PPT structure planner. Plan slide titles and concise key points from the user's topic, requirements, and source-material brief.",
     "",
     CONTENT_LANGUAGE_RULES,
+    "",
+    "## Current date",
+    `- ${currentDate}`,
+    "- If the user asks for latest, current, recent, near-term, today, this week, this month, real-time, or news-like content, use the current date as the time anchor.",
+    "- Unless the user explicitly requests historical review, do not default slide titles or key points to stale years or months.",
+    "- If exact dates are uncertain at planning time, prefer relative expressions such as recent updates or the last two days over inventing outdated calendar dates.",
     "",
     "## Hard constraints",
     `Return exactly ${totalPages} slide plans. The JSON array length must equal ${totalPages}.`,

--- a/src/main/prompt/runtime-user.ts
+++ b/src/main/prompt/runtime-user.ts
@@ -1,16 +1,20 @@
-import { CONTENT_LANGUAGE_RULES } from "./shared";
+import { CONTENT_LANGUAGE_RULES, formatCurrentDate } from "./shared";
 
 export function buildPlanningUserPrompt(args: {
   topic: string;
   totalPages: number;
   userMessage: string;
 }): string {
+  const currentDate = formatCurrentDate();
   const hasExplicitPageHint = /第\s*\d+\s*页|(?:page|slide)\s*\d+/i.test(args.userMessage);
   return [
     `Topic: ${args.topic}`,
+    `Current date: ${currentDate}`,
     `Target slide count: ${args.totalPages}`,
     `Return exactly ${args.totalPages} slides, no more and no fewer.`,
     hasExplicitPageHint ? "The user provided page/slide hints. Preserve that pagination intent when possible." : "",
+    "If the user mentions latest, current, recent, the last two days, today, this week, this month, live, or news, do not default to stale years or months.",
+    "If the user does not explicitly request a historical period, interpret time-sensitive wording using the current date.",
     "",
     "Plan each slide title, key points, and layout intent. Use short phrases, not long paragraphs.",
     "Output must be a JSON array. Each item must be exactly { title, keyPoints, layoutIntent }; keyPoints must contain 1-6 strings.",

--- a/src/main/prompt/shared.ts
+++ b/src/main/prompt/shared.ts
@@ -112,6 +112,10 @@ export function resolveStylePrompt(
   };
 }
 
+export function formatCurrentDate(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
 export function buildOutlinePageList(context: SessionDeckGenerationContext): string {
   return context.outlineItems
     .map((item, i) => {

--- a/src/main/tools/deck-tools.ts
+++ b/src/main/tools/deck-tools.ts
@@ -8,6 +8,8 @@ import { emitToolStatus } from "./types";
 import { validateHtmlContent } from "./html-utils";
 import { buildSessionAssetHeadTags } from "../ipc/page-assets";
 import { progressLabel } from "@shared/progress";
+import { callFetchWebContent, callWebSearch } from "../utils/web-search";
+import { checkDaemonHealth } from "../utils/web-search-service";
 
 const uiText = (locale: "zh" | "en" | undefined, zh: string, en: string): string => (locale === "en" ? en : zh);
 
@@ -914,6 +916,102 @@ export function createSessionBoundDeckTools(context: SessionDeckGenerationContex
     return result;
   };
 
+  const resolvedEngines =
+    Array.isArray(context.webSearchEngines) && context.webSearchEngines.length > 0
+      ? context.webSearchEngines
+      : ["bing", "duckduckgo"];
+  const resolvedLimit =
+    typeof context.webSearchLimit === "number" && Number.isFinite(context.webSearchLimit)
+      ? Math.max(1, Math.min(20, Math.round(context.webSearchLimit)))
+      : 20;
+  const searchTools =
+    context.allowWebSearch === true
+      ? [
+          tool(
+            async ({ query }, config) => {
+              emitNormalizedToolStatus(config, {
+                label: uiText(context.appLocale, `联网搜索：${query}`, `Web search: ${query}`),
+                detail: uiText(
+                  context.appLocale,
+                  `引擎: ${resolvedEngines.join(", ")}`,
+                  `Engines: ${resolvedEngines.join(", ")}`
+                ),
+                progress: 20
+              });
+              const healthy = await checkDaemonHealth();
+              if (!healthy) {
+                throw new Error(
+                  uiText(
+                    context.appLocale,
+                    "open-websearch 本地服务未启动，请先在设置页安装或启动联网搜索服务。",
+                    "The local open-websearch service is not running. Install or start it from Settings first."
+                  )
+                );
+              }
+              const result = await callWebSearch({
+                query,
+                limit: resolvedLimit,
+                engines: resolvedEngines
+              });
+              emitNormalizedToolStatus(config, {
+                label: uiText(
+                  context.appLocale,
+                  `搜索完成，共 ${result.totalResults} 条结果`,
+                  `Search completed with ${result.totalResults} results`
+                ),
+                progress: 40
+              });
+              return JSON.stringify(result, null, 2);
+            },
+            {
+              name: "web_search",
+              description:
+                "Search the web for current information before writing PPT content. Engines and result limit come from user settings; only provide the query.",
+              schema: z.object({
+                query: z.string().min(1).describe("Search query")
+              })
+            }
+          ),
+          tool(
+            async ({ url, maxChars }, config) => {
+              emitNormalizedToolStatus(config, {
+                label: uiText(context.appLocale, `抓取网页内容：${url}`, `Fetching page content: ${url}`),
+                progress: 20
+              });
+              const healthy = await checkDaemonHealth();
+              if (!healthy) {
+                throw new Error(
+                  uiText(
+                    context.appLocale,
+                    "open-websearch 本地服务未启动，请先在设置页安装或启动联网搜索服务。",
+                    "The local open-websearch service is not running. Install or start it from Settings first."
+                  )
+                );
+              }
+              const result = await callFetchWebContent({ url, maxChars });
+              emitNormalizedToolStatus(config, {
+                label: uiText(
+                  context.appLocale,
+                  `网页内容抓取完成：${result.content.length} 字符`,
+                  `Fetched page content: ${result.content.length} chars`
+                ),
+                progress: 40
+              });
+              return JSON.stringify(result, null, 2);
+            },
+            {
+              name: "fetch_web_content",
+              description:
+                "Fetch readable content for a public URL. Use after web_search when snippets are insufficient and more detail is needed.",
+              schema: z.object({
+                url: z.string().url().describe("Public HTTP(S) URL"),
+                maxChars: z.number().int().min(1000).max(50000).optional().default(8000)
+              })
+            }
+          )
+        ]
+      : [];
+
   return [
     // ── get_session_context ──
     tool(
@@ -1303,6 +1401,7 @@ export function createSessionBoundDeckTools(context: SessionDeckGenerationContex
           "Verify that all page files have been filled correctly. Use after update_single_page_file or update_page_file.",
         schema: z.object({})
       }
-    )
+    ),
+    ...searchTools
   ];
 }

--- a/src/main/tools/types.ts
+++ b/src/main/tools/types.ts
@@ -42,6 +42,9 @@ export interface SessionDeckGenerationContext {
   topic: string;
   deckTitle: string;
   styleId: string | null | undefined;
+  allowWebSearch?: boolean;
+  webSearchEngines?: string[];
+  webSearchLimit?: number;
   /** Snapshot of the database styleSkill markdown for this run. */
   styleSkillPrompt?: string;
   appLocale?: "zh" | "en";

--- a/src/main/utils/web-search-service.ts
+++ b/src/main/utils/web-search-service.ts
@@ -1,0 +1,285 @@
+import { app } from 'electron'
+import { spawn } from 'child_process'
+import fs from 'fs'
+import path from 'path'
+
+const DAEMON_BASE_URL =
+  (process.env.WEBSEARCH_DAEMON_URL || process.env.OPEN_WEBSEARCH_DAEMON_URL || '').trim() ||
+  'http://127.0.0.1:3210'
+const HEALTHCHECK_TIMEOUT_MS = 3000
+const START_TIMEOUT_MS = 12000
+const INSTALL_TIMEOUT_MS = 10 * 60 * 1000
+const MANAGED_SERVICE_DIRNAME = 'open-websearch-service'
+const MANAGED_PACKAGE_SPEC = 'open-websearch@2.1.8'
+const STARTED_PID_FILENAME = 'daemon.pid'
+
+export const SUPPORTED_WEB_SEARCH_ENGINES = [
+  'bing',
+  'duckduckgo',
+  'baidu',
+  'brave',
+  'csdn',
+  'exa',
+  'juejin',
+  'linuxdo',
+  'startpage',
+] as const
+
+export const DEFAULT_WEB_SEARCH_ENGINES = ['bing', 'duckduckgo']
+export const DEFAULT_WEB_SEARCH_LIMIT = 20
+export const DEFAULT_WEB_SEARCH_PROXY_URL = 'http://127.0.0.1:7897'
+
+export type WebSearchServiceStatus = {
+  daemonUrl: string
+  running: boolean
+  installed: boolean
+  installSource: 'managed' | 'workspace' | 'none'
+  installDir: string
+  workspaceDir: string
+  canInstall: boolean
+  canStart: boolean
+}
+
+export type WebSearchProxyConfig = {
+  useProxy?: boolean
+  proxyUrl?: string
+}
+
+function getManagedServiceDir(): string {
+  return path.join(app.getPath('userData'), MANAGED_SERVICE_DIRNAME)
+}
+
+function getStartedPidPath(): string {
+  return path.join(getManagedServiceDir(), STARTED_PID_FILENAME)
+}
+
+function getWorkspaceServiceDir(): string {
+  return path.resolve(process.cwd(), 'open-webSearch-main')
+}
+
+function getManagedScriptPath(): string {
+  return path.join(getManagedServiceDir(), 'node_modules', 'open-websearch', 'build', 'index.js')
+}
+
+function getWorkspaceScriptPath(): string {
+  return path.join(getWorkspaceServiceDir(), 'build', 'index.js')
+}
+
+function resolveInstalledSource(): { source: 'managed' | 'workspace' | 'none'; scriptPath?: string } {
+  const managedScriptPath = getManagedScriptPath()
+  if (fs.existsSync(managedScriptPath)) {
+    return { source: 'managed', scriptPath: managedScriptPath }
+  }
+
+  const workspaceScriptPath = getWorkspaceScriptPath()
+  if (fs.existsSync(workspaceScriptPath)) {
+    return { source: 'workspace', scriptPath: workspaceScriptPath }
+  }
+
+  return { source: 'none' }
+}
+
+async function delay(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+async function writeStartedPid(pid: number): Promise<void> {
+  await fs.promises.mkdir(getManagedServiceDir(), { recursive: true })
+  await fs.promises.writeFile(getStartedPidPath(), String(pid), 'utf-8')
+}
+
+async function readStartedPid(): Promise<number | null> {
+  try {
+    const raw = await fs.promises.readFile(getStartedPidPath(), 'utf-8')
+    const pid = Number.parseInt(raw.trim(), 10)
+    return Number.isFinite(pid) && pid > 0 ? pid : null
+  } catch {
+    return null
+  }
+}
+
+async function clearStartedPid(): Promise<void> {
+  try {
+    await fs.promises.unlink(getStartedPidPath())
+  } catch {
+    // ignore
+  }
+}
+
+async function runCommand(
+  command: string,
+  args: string[],
+  cwd: string,
+  timeoutMs: number,
+): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const isWindows = process.platform === 'win32'
+    const spawnCommand = isWindows ? 'cmd.exe' : command
+    const spawnArgs = isWindows ? ['/d', '/s', '/c', command, ...args] : args
+
+    const child = spawn(spawnCommand, spawnArgs, {
+      cwd,
+      stdio: 'pipe',
+      windowsHide: true,
+      env: process.env,
+    })
+
+    let stdout = ''
+    let stderr = ''
+    const timeout = setTimeout(() => {
+      child.kill()
+      reject(new Error(`Command timed out: ${command} ${args.join(' ')}`))
+    }, timeoutMs)
+
+    child.stdout?.on('data', (chunk) => {
+      stdout += String(chunk)
+    })
+    child.stderr?.on('data', (chunk) => {
+      stderr += String(chunk)
+    })
+    child.on('error', (error) => {
+      clearTimeout(timeout)
+      reject(error)
+    })
+    child.on('exit', (code) => {
+      clearTimeout(timeout)
+      if (code === 0) {
+        resolve()
+        return
+      }
+      reject(new Error((stderr || stdout || `Exit code ${code}`).trim()))
+    })
+  })
+}
+
+export async function checkDaemonHealth(): Promise<boolean> {
+  try {
+    const controller = new AbortController()
+    const timeout = setTimeout(() => controller.abort(), HEALTHCHECK_TIMEOUT_MS)
+    const response = await fetch(`${DAEMON_BASE_URL}/health`, {
+      signal: controller.signal,
+    })
+    clearTimeout(timeout)
+    return response.ok
+  } catch {
+    return false
+  }
+}
+
+export async function getWebSearchServiceStatus(): Promise<WebSearchServiceStatus> {
+  const running = await checkDaemonHealth()
+  const installedSource = resolveInstalledSource()
+
+  return {
+    daemonUrl: DAEMON_BASE_URL,
+    running,
+    installed: installedSource.source !== 'none',
+    installSource: installedSource.source,
+    installDir: getManagedServiceDir(),
+    workspaceDir: getWorkspaceServiceDir(),
+    canInstall: installedSource.source === 'none',
+    canStart: installedSource.source !== 'none' && !running,
+  }
+}
+
+export async function installWebSearchService(): Promise<WebSearchServiceStatus> {
+  const currentStatus = await getWebSearchServiceStatus()
+  if (currentStatus.installed) {
+    return currentStatus
+  }
+
+  const installDir = getManagedServiceDir()
+  await fs.promises.mkdir(installDir, { recursive: true })
+
+  const packageJsonPath = path.join(installDir, 'package.json')
+  if (!fs.existsSync(packageJsonPath)) {
+    await fs.promises.writeFile(
+      packageJsonPath,
+      JSON.stringify(
+        {
+          name: 'oh-my-ppt-websearch-service',
+          private: true,
+        },
+        null,
+        2,
+      ),
+      'utf-8',
+    )
+  }
+
+  const npmCommand = process.platform === 'win32' ? 'npm.cmd' : 'npm'
+  await runCommand(npmCommand, ['install', '--no-save', MANAGED_PACKAGE_SPEC], installDir, INSTALL_TIMEOUT_MS)
+  return getWebSearchServiceStatus()
+}
+
+export async function startWebSearchService(proxyConfig?: WebSearchProxyConfig): Promise<WebSearchServiceStatus> {
+  const currentStatus = await getWebSearchServiceStatus()
+  if (currentStatus.running) {
+    return currentStatus
+  }
+
+  const installedSource = resolveInstalledSource()
+  if (!installedSource.scriptPath) {
+    throw new Error('open-websearch 尚未安装')
+  }
+
+  const workingDirectory =
+    installedSource.source === 'workspace' ? getWorkspaceServiceDir() : getManagedServiceDir()
+  const useProxy = proxyConfig?.useProxy === true
+  const proxyUrl = (proxyConfig?.proxyUrl || '').trim()
+
+  const child = spawn(process.execPath, [installedSource.scriptPath, 'serve'], {
+    cwd: workingDirectory,
+    detached: true,
+    stdio: 'ignore',
+    windowsHide: true,
+    env: {
+      ...process.env,
+      ELECTRON_RUN_AS_NODE: '1',
+      ...(useProxy ? { USE_PROXY: 'true' } : {}),
+      ...(useProxy && proxyUrl ? { PROXY_URL: proxyUrl } : {}),
+    },
+  })
+  if (typeof child.pid !== 'number' || child.pid <= 0) {
+    throw new Error('open-websearch 启动失败：未获取到进程 PID')
+  }
+  await writeStartedPid(child.pid)
+  child.unref()
+
+  const startDeadline = Date.now() + START_TIMEOUT_MS
+  while (Date.now() < startDeadline) {
+    if (await checkDaemonHealth()) {
+      return getWebSearchServiceStatus()
+    }
+    await delay(500)
+  }
+
+  throw new Error('open-websearch 启动超时，请检查服务日志或端口占用')
+}
+
+export async function stopManagedWebSearchService(): Promise<boolean> {
+  const pid = await readStartedPid()
+  if (!pid) {
+    return false
+  }
+
+  try {
+    process.kill(pid)
+  } catch {
+    await clearStartedPid()
+    return false
+  }
+
+  const stopDeadline = Date.now() + 5000
+  while (Date.now() < stopDeadline) {
+    const running = await checkDaemonHealth()
+    if (!running) {
+      await clearStartedPid()
+      return true
+    }
+    await delay(200)
+  }
+
+  await clearStartedPid()
+  return true
+}

--- a/src/main/utils/web-search.ts
+++ b/src/main/utils/web-search.ts
@@ -1,0 +1,209 @@
+import log from 'electron-log/main.js'
+import {
+  DEFAULT_WEB_SEARCH_ENGINES,
+  DEFAULT_WEB_SEARCH_LIMIT,
+} from './web-search-service'
+export { checkDaemonHealth } from './web-search-service'
+
+const DAEMON_BASE_URL =
+  (process.env.WEBSEARCH_DAEMON_URL || process.env.OPEN_WEBSEARCH_DAEMON_URL || '').trim() ||
+  'http://127.0.0.1:3210'
+const REQUEST_TIMEOUT_MS = 15000
+
+interface DaemonEnvelope<T> {
+  status: 'ok' | 'error'
+  data: T | null
+  error: { code: string; message: string } | null
+  hint: string | null
+}
+
+export interface WebSearchResult {
+  title: string
+  url: string
+  description: string
+  source?: string
+  engine?: string
+}
+
+export interface WebSearchResponse {
+  query: string
+  engines: string[]
+  totalResults: number
+  results: WebSearchResult[]
+  partialFailures?: Array<{ engine: string; message: string }>
+}
+
+export interface FetchWebContentResponse {
+  url: string
+  finalUrl: string
+  contentType?: string
+  title?: string
+  truncated: boolean
+  content: string
+}
+
+function extractMarkdownFallbackTitle(markdown: string): string | undefined {
+  const titleLine = markdown.match(/^Title:\s*(.+)$/m)
+  if (titleLine?.[1]) return titleLine[1].trim()
+
+  const headingLine = markdown.match(/^#\s+(.+)$/m)
+  if (headingLine?.[1]) return headingLine[1].trim()
+
+  return undefined
+}
+
+async function fetchViaMarkdownMirror(url: string, maxChars: number): Promise<FetchWebContentResponse> {
+  const mirrorUrl = `https://markdown.new/${url}`
+  log.info('[web-search] fetchViaMarkdownMirror', { url, mirrorUrl, maxChars })
+
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS)
+
+  try {
+    const response = await fetch(mirrorUrl, {
+      signal: controller.signal,
+      headers: {
+        Accept: 'text/markdown,text/plain;q=0.9,*/*;q=0.8',
+      },
+    })
+    clearTimeout(timeout)
+
+    if (!response.ok) {
+      const text = await response.text().catch(() => '')
+      throw new Error(`markdown mirror returned HTTP ${response.status}: ${text}`)
+    }
+
+    const raw = await response.text()
+    const normalized = raw.trim()
+    const title = extractMarkdownFallbackTitle(normalized)
+    const truncated = normalized.length > maxChars
+    const content = truncated
+      ? `${normalized.slice(0, maxChars)}\n\n[...truncated ${normalized.length - maxChars} characters]`
+      : normalized
+
+    return {
+      url,
+      finalUrl: mirrorUrl,
+      contentType: 'text/markdown',
+      title,
+      truncated,
+      content,
+    }
+  } catch (error) {
+    clearTimeout(timeout)
+    throw error
+  }
+}
+
+function unwrapEnvelope<T>(envelope: DaemonEnvelope<T>, context: string): T {
+  if (envelope.status === 'error' || envelope.error) {
+    throw new Error(`${context} failed: ${envelope.error?.message || 'unknown daemon error'}`)
+  }
+  if (envelope.data === null || envelope.data === undefined) {
+    throw new Error(`${context} returned empty data`)
+  }
+  return envelope.data
+}
+
+export async function callWebSearch(args: {
+  query: string
+  limit?: number
+  engines?: string[]
+}): Promise<WebSearchResponse> {
+  const { query, limit = DEFAULT_WEB_SEARCH_LIMIT, engines = DEFAULT_WEB_SEARCH_ENGINES } = args
+
+  log.info('[web-search] callWebSearch', { query, limit, engines, daemonUrl: DAEMON_BASE_URL })
+
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS)
+
+  try {
+    const response = await fetch(`${DAEMON_BASE_URL}/search`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ query, limit, engines }),
+      signal: controller.signal
+    })
+    clearTimeout(timeout)
+
+    if (!response.ok) {
+      const text = await response.text().catch(() => '')
+      throw new Error(`daemon returned HTTP ${response.status}: ${text}`)
+    }
+
+    const envelope = (await response.json()) as DaemonEnvelope<WebSearchResponse>
+    const data = unwrapEnvelope(envelope, 'search')
+
+    log.info('[web-search] callWebSearch success', {
+      query,
+      totalResults: data.totalResults,
+      partialFailures: data.partialFailures?.length ?? 0
+    })
+    return data
+  } catch (error) {
+    clearTimeout(timeout)
+    const message = error instanceof Error ? error.message : String(error)
+    log.warn('[web-search] callWebSearch failed', { query, message, daemonUrl: DAEMON_BASE_URL })
+    throw new Error(`web search failed: ${message}`)
+  }
+}
+
+export async function callFetchWebContent(args: {
+  url: string
+  maxChars?: number
+}): Promise<FetchWebContentResponse> {
+  const { url, maxChars = 8000 } = args
+
+  log.info('[web-search] callFetchWebContent', { url, maxChars, daemonUrl: DAEMON_BASE_URL })
+
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS)
+
+  try {
+    const response = await fetch(`${DAEMON_BASE_URL}/fetch-web`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ url, maxChars }),
+      signal: controller.signal
+    })
+    clearTimeout(timeout)
+
+    if (!response.ok) {
+      const text = await response.text().catch(() => '')
+      throw new Error(`daemon returned HTTP ${response.status}: ${text}`)
+    }
+
+    const envelope = (await response.json()) as DaemonEnvelope<FetchWebContentResponse>
+    const data = unwrapEnvelope(envelope, 'fetch_web_content')
+
+    log.info('[web-search] callFetchWebContent success', {
+      url,
+      contentLength: data.content?.length ?? 0,
+      truncated: data.truncated
+    })
+    return data
+  } catch (error) {
+    clearTimeout(timeout)
+    const message = error instanceof Error ? error.message : String(error)
+    log.warn('[web-search] callFetchWebContent failed', { url, message, daemonUrl: DAEMON_BASE_URL })
+
+    try {
+      const fallback = await fetchViaMarkdownMirror(url, maxChars)
+      log.info('[web-search] callFetchWebContent fallback success', {
+        url,
+        finalUrl: fallback.finalUrl,
+        contentLength: fallback.content.length,
+      })
+      return fallback
+    } catch (fallbackError) {
+      const fallbackMessage =
+        fallbackError instanceof Error ? fallbackError.message : String(fallbackError)
+      log.warn('[web-search] callFetchWebContent fallback failed', {
+        url,
+        message,
+        fallbackMessage,
+      })
+      throw new Error(`fetch web content failed: ${message}; markdown fallback failed: ${fallbackMessage}`)
+    }
+  }
+}

--- a/src/renderer/src/lib/ipc.ts
+++ b/src/renderer/src/lib/ipc.ts
@@ -106,6 +106,7 @@ export interface CreateSessionPayload {
   styleId: string
   pageCount?: number
   referenceDocumentPath?: string
+  allowWebSearch?: boolean
 }
 
 export interface ModelConfig {
@@ -118,6 +119,17 @@ export interface ModelConfig {
   active: boolean
   createdAt: number
   updatedAt: number
+}
+
+export interface WebSearchServiceStatus {
+  daemonUrl: string
+  running: boolean
+  installed: boolean
+  installSource: 'managed' | 'workspace' | 'none'
+  installDir: string
+  workspaceDir: string
+  canInstall: boolean
+  canStart: boolean
 }
 
 export const ipc = {
@@ -185,6 +197,12 @@ export const ipc = {
   listModelConfigs: () => getIpc().invoke('settings:listModelConfigs') as Promise<ModelConfig[]>,
   saveSettings: (settings: Record<string, unknown>) =>
     getIpc().invoke('settings:save', settings) as Promise<{ success: boolean }>,
+  getWebSearchServiceStatus: () =>
+    getIpc().invoke('settings:getWebSearchServiceStatus') as Promise<WebSearchServiceStatus>,
+  installWebSearchService: () =>
+    getIpc().invoke('settings:installWebSearchService') as Promise<WebSearchServiceStatus>,
+  startWebSearchService: () =>
+    getIpc().invoke('settings:startWebSearchService') as Promise<WebSearchServiceStatus>,
   upsertModelConfig: (payload: {
     id?: string
     name: string

--- a/src/renderer/src/pages/home.tsx
+++ b/src/renderer/src/pages/home.tsx
@@ -53,6 +53,7 @@ export function HomePage(): ReactElement {
   const [topic, setTopic] = useState('')
   const [brief, setBrief] = useState('')
   const [pageCount, setPageCount] = useState(String(DEFAULT_PAGE_COUNT))
+  const [allowWebSearch, setAllowWebSearch] = useState(false)
   const [selectedStyleId, setSelectedStyleId] = useState('')
   const [styleOptions, setStyleOptions] = useState<
     Array<{ id: string; label: string; description: string }>
@@ -104,6 +105,8 @@ export function HomePage(): ReactElement {
     const n = Number.parseInt(pageCountText, 10)
     return n >= MIN_PAGE_COUNT && n <= MAX_PAGE_COUNT
   })()
+  const isEnglish = settings?.locale === 'en'
+  const webSearchReady = settings?.webSearch?.serviceStatus?.running === true
 
   useEffect(() => {
     ipc
@@ -153,7 +156,8 @@ export function HomePage(): ReactElement {
         topic: topicText,
         styleId: selectedStyleId,
         pageCount: safePageCount,
-        referenceDocumentPath: referenceDocumentPath || undefined
+        referenceDocumentPath: referenceDocumentPath || undefined,
+        allowWebSearch
       })
       success(t('home.sessionCreated'), {
         description: t('home.generationStarted'),
@@ -499,6 +503,32 @@ export function HomePage(): ReactElement {
                 className="min-h-[132px] resize-y"
               />
             </div>
+
+            <label
+              className={`flex items-start gap-3 rounded-md border border-border/70 px-4 py-3 ${webSearchReady ? '' : 'opacity-70'}`}
+            >
+              <input
+                type="checkbox"
+                checked={allowWebSearch}
+                onChange={(e) => setAllowWebSearch(e.target.checked)}
+                disabled={!webSearchReady}
+                className="mt-1 h-4 w-4 rounded border-border text-primary"
+              />
+              <span className="space-y-1">
+                <span className="block text-sm font-medium">
+                  {isEnglish ? 'Allow web search' : '允许联网搜索'}
+                </span>
+                <span className="block text-xs text-muted-foreground">
+                  {webSearchReady
+                    ? isEnglish
+                      ? 'When enabled, the AI may use web search for recent information and verifiable real-world data.'
+                      : '开启后，AI 才会获得联网搜索权限，用于检索最新信息和可核实的现实数据。'
+                    : isEnglish
+                      ? 'Start the web search service in Settings before enabling this option.'
+                      : '请先在系统设置中启动联网搜索服务，再开启这个选项。'}
+                </span>
+              </span>
+            </label>
           </CardContent>
         </Card>
 

--- a/src/renderer/src/pages/settings.tsx
+++ b/src/renderer/src/pages/settings.tsx
@@ -12,7 +12,19 @@ import {
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '../components/ui/Tabs'
 import { useSettingsStore } from '../store'
 import { useToastStore } from '../store'
-import { CheckCircle2, FolderSearch, Pencil, Plus, ShieldCheck, Trash2, X } from 'lucide-react'
+import {
+  CheckCircle2,
+  Download,
+  FolderSearch,
+  Pencil,
+  Play,
+  Plus,
+  RefreshCw,
+  Search,
+  ShieldCheck,
+  Trash2,
+  X
+} from 'lucide-react'
 import { useLang } from '../i18n'
 import type { ModelConfig } from '../lib/ipc'
 import {
@@ -23,6 +35,18 @@ import {
 } from '@shared/model-timeout.js'
 
 type ProviderId = 'anthropic' | 'openai'
+
+const WEB_SEARCH_ENGINE_OPTIONS = [
+  { value: 'bing', label: 'Bing' },
+  { value: 'duckduckgo', label: 'DuckDuckGo' },
+  { value: 'baidu', label: 'Baidu' },
+  { value: 'brave', label: 'Brave' },
+  { value: 'csdn', label: 'CSDN' },
+  { value: 'exa', label: 'Exa' },
+  { value: 'juejin', label: 'Juejin' },
+  { value: 'linuxdo', label: 'LinuxDo' },
+  { value: 'startpage', label: 'Startpage' }
+] as const
 
 interface ModelForm {
   id?: string
@@ -65,6 +89,7 @@ const createModelForm = (config: ModelConfig): ModelForm => ({
 
 export function SettingsPage(): React.JSX.Element {
   const {
+    settings,
     modelConfigs,
     fetchSettings,
     saveSettings,
@@ -73,7 +98,12 @@ export function SettingsPage(): React.JSX.Element {
     deleteModelConfig,
     setVerificationMessage,
     verifyApiKey,
-    chooseStoragePath
+    chooseStoragePath,
+    refreshWebSearchServiceStatus,
+    installWebSearchService,
+    startWebSearchService,
+    webSearchError,
+    webSearchBusy
   } = useSettingsStore()
   const { success, error, warning, info } = useToastStore()
   const { lang, setLang, t } = useLang()
@@ -90,6 +120,10 @@ export function SettingsPage(): React.JSX.Element {
   const [verifying, setVerifying] = useState(false)
   const [activatingId, setActivatingId] = useState<string | null>(null)
   const [deletingId, setDeletingId] = useState<string | null>(null)
+  const [webSearchLimit, setWebSearchLimit] = useState('20')
+  const [webSearchEngines, setWebSearchEngines] = useState<string[]>(['bing', 'duckduckgo'])
+  const [webSearchUseProxy, setWebSearchUseProxy] = useState(false)
+  const [webSearchProxyUrl, setWebSearchProxyUrl] = useState('http://127.0.0.1:7897')
 
   useEffect(() => {
     let active = true
@@ -99,6 +133,12 @@ export function SettingsPage(): React.JSX.Element {
       const nextSettings = useSettingsStore.getState().settings
       setStoragePath(nextSettings?.storagePath || '')
       setTimeoutSeconds(createTimeoutSeconds(nextSettings?.timeouts))
+      setWebSearchLimit(String(nextSettings?.webSearch?.limit || 20))
+      setWebSearchEngines(
+        nextSettings?.webSearch?.engines?.length ? nextSettings.webSearch.engines : ['bing', 'duckduckgo']
+      )
+      setWebSearchUseProxy(nextSettings?.webSearch?.useProxy === true)
+      setWebSearchProxyUrl(nextSettings?.webSearch?.proxyUrl || 'http://127.0.0.1:7897')
     }
     void loadSettings()
     return () => {
@@ -329,6 +369,101 @@ export function SettingsPage(): React.JSX.Element {
     }
   }
 
+  const toggleEngine = (engine: string, checked: boolean): void => {
+    setWebSearchEngines((current) => {
+      if (checked) {
+        return current.includes(engine) ? current : [...current, engine]
+      }
+      return current.filter((item) => item !== engine)
+    })
+  }
+
+  const handleInstallWebSearch = async (): Promise<void> => {
+    const installed = await installWebSearchService()
+    if (installed) {
+      success(lang === 'en' ? 'Web search service installed' : '联网搜索服务已安装', {
+        description:
+          lang === 'en'
+            ? 'You can start the service now.'
+            : '现在可以继续启动服务。'
+      })
+      return
+    }
+    error(lang === 'en' ? 'Failed to install web search service' : '联网搜索服务安装失败', {
+      description:
+        webSearchError || (lang === 'en' ? t('common.retryLater') : '请稍后重试。')
+    })
+  }
+
+  const handleStartWebSearch = async (): Promise<void> => {
+    const started = await startWebSearchService()
+    if (started) {
+      success(lang === 'en' ? 'Web search service started' : '联网搜索服务已启动', {
+        description:
+          lang === 'en'
+            ? 'The home page can enable web search now.'
+            : '首页现在可以开启联网搜索。'
+      })
+      return
+    }
+    error(lang === 'en' ? 'Failed to start web search service' : '联网搜索服务启动失败', {
+      description:
+        webSearchError || (lang === 'en' ? t('common.retryLater') : '请稍后重试。')
+    })
+  }
+
+  const handleSaveWebSearch = async (): Promise<void> => {
+    const normalizedLimit = Number.parseInt(webSearchLimit.trim(), 10)
+    if (!Number.isFinite(normalizedLimit) || normalizedLimit < 1 || normalizedLimit > 20) {
+      warning(lang === 'en' ? 'Enter a result limit between 1 and 20' : '请填写 1-20 之间的搜索结果数量')
+      return
+    }
+    if (!webSearchEngines.length) {
+      warning(lang === 'en' ? 'Select at least one search engine' : '请至少选择一个联网搜索引擎')
+      return
+    }
+    if (webSearchUseProxy && !webSearchProxyUrl.trim()) {
+      warning(lang === 'en' ? 'Enter a proxy URL' : '请填写代理地址')
+      return
+    }
+
+    await saveSettings({
+      webSearch: {
+        engines: webSearchEngines,
+        limit: normalizedLimit,
+        useProxy: webSearchUseProxy,
+        proxyUrl: webSearchProxyUrl.trim()
+      }
+    })
+    const saveError = useSettingsStore.getState().verificationMessage
+    if (saveError) {
+      error(t('settings.saveFailed'), { description: saveError })
+      return
+    }
+    success(t('settings.saved'), {
+      description:
+        lang === 'en'
+          ? 'Web search configuration has been written locally'
+          : '联网搜索配置已写入本地'
+    })
+  }
+
+  const serviceStatus = settings?.webSearch?.serviceStatus
+  const serviceBadge = serviceStatus?.running
+    ? {
+        label: lang === 'en' ? 'Running' : '运行中',
+        className: 'bg-emerald-50 text-emerald-700 border-emerald-200'
+      }
+    : serviceStatus?.installed
+      ? {
+          label: lang === 'en' ? 'Installed' : '已安装',
+          className: 'bg-amber-50 text-amber-700 border-amber-200'
+        }
+      : {
+          label: lang === 'en' ? 'Not installed' : '未安装',
+          className: 'bg-slate-100 text-slate-600 border-slate-200'
+        }
+
   return (
     <div className="mx-auto max-w-4xl p-6">
       <div className="mb-5">
@@ -505,7 +640,175 @@ export function SettingsPage(): React.JSX.Element {
             </CardContent>
           </Card>
 
-          <div className="flex justify-end">
+          <Card className="mb-4">
+            <CardHeader className="p-5 pb-3">
+              <CardTitle className="text-base">
+                {lang === 'en' ? 'Web search' : '联网搜索'}
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4 p-5 pt-0">
+              <div className="flex flex-wrap items-center gap-3">
+                <div className="flex items-center gap-2">
+                  <Search className="h-4 w-4 text-[#5d6b4d]" />
+                  <span className="text-sm font-medium">open-websearch</span>
+                </div>
+                <span className={`rounded-full border px-2.5 py-1 text-xs ${serviceBadge.className}`}>
+                  {serviceBadge.label}
+                </span>
+                <Button
+                  variant="secondary"
+                  onClick={() => {
+                    void refreshWebSearchServiceStatus()
+                  }}
+                  disabled={webSearchBusy}
+                  className="h-10 rounded-lg border border-[#7ea06f]/45"
+                >
+                  <RefreshCw className="mr-1.5 h-4 w-4" />
+                  {lang === 'en' ? 'Refresh' : '刷新状态'}
+                </Button>
+                {!serviceStatus?.installed ? (
+                  <Button
+                    variant="secondary"
+                    onClick={() => {
+                      void handleInstallWebSearch()
+                    }}
+                    disabled={webSearchBusy}
+                    className="h-10 rounded-lg border border-[#7ea06f]/45"
+                  >
+                    <Download className="mr-1.5 h-4 w-4" />
+                    {lang === 'en' ? 'Install' : '一键安装'}
+                  </Button>
+                ) : null}
+                {serviceStatus?.installed && !serviceStatus.running ? (
+                  <Button
+                    variant="secondary"
+                    onClick={() => {
+                      void handleStartWebSearch()
+                    }}
+                    disabled={webSearchBusy}
+                    className="h-10 rounded-lg border border-[#7ea06f]/45"
+                  >
+                    <Play className="mr-1.5 h-4 w-4" />
+                    {lang === 'en' ? 'Start' : '一键启动'}
+                  </Button>
+                ) : null}
+              </div>
+
+              <div className="space-y-1 text-xs text-muted-foreground">
+                <p>URL: {serviceStatus?.daemonUrl || 'http://127.0.0.1:3210'}</p>
+                {serviceStatus?.installSource === 'workspace' ? (
+                  <p>
+                    {lang === 'en'
+                      ? 'Using open-webSearch-main from the workspace.'
+                      : '当前使用工作区内的 open-webSearch-main。'}
+                  </p>
+                ) : null}
+                {serviceStatus?.installSource === 'managed' ? (
+                  <p>
+                    {lang === 'en'
+                      ? 'Using the app-managed open-websearch service.'
+                      : '当前使用应用托管安装的 open-websearch 服务。'}
+                  </p>
+                ) : null}
+                {webSearchError ? <p className="text-destructive">{webSearchError}</p> : null}
+              </div>
+
+              <div>
+                <label className="mb-2 block text-sm font-medium">
+                  {lang === 'en' ? 'Search engines' : '搜索引擎'}
+                </label>
+                <div className="grid grid-cols-2 gap-2 md:grid-cols-3">
+                  {WEB_SEARCH_ENGINE_OPTIONS.map((engine) => (
+                    <label
+                      key={engine.value}
+                      className="flex items-center gap-2 rounded-md border border-border/70 px-3 py-2 text-sm"
+                    >
+                      <input
+                        type="checkbox"
+                        checked={webSearchEngines.includes(engine.value)}
+                        onChange={(e) => toggleEngine(engine.value, e.target.checked)}
+                        className="h-4 w-4 rounded border-border text-primary"
+                      />
+                      <span>{engine.label}</span>
+                    </label>
+                  ))}
+                </div>
+              </div>
+
+              <div>
+                <label className="mb-2 block text-sm font-medium">
+                  {lang === 'en' ? 'Result limit' : '返回结果数量'}
+                </label>
+                <Input
+                  type="text"
+                  inputMode="numeric"
+                  pattern="[0-9]*"
+                  value={webSearchLimit}
+                  onChange={(e) => {
+                    const next = e.target.value
+                    if (next === '' || /^\d+$/.test(next)) {
+                      setWebSearchLimit(next)
+                    }
+                  }}
+                  onBlur={() => {
+                    const parsed = Number.parseInt(webSearchLimit || '20', 10)
+                    const normalized =
+                      Number.isFinite(parsed) ? Math.max(1, Math.min(20, parsed)) : 20
+                    setWebSearchLimit(String(normalized))
+                  }}
+                />
+              </div>
+
+              <label className="flex items-start gap-3 rounded-md border border-border/70 px-4 py-3">
+                <input
+                  type="checkbox"
+                  checked={webSearchUseProxy}
+                  onChange={(e) => setWebSearchUseProxy(e.target.checked)}
+                  className="mt-1 h-4 w-4 rounded border-border text-primary"
+                />
+                <span className="space-y-1">
+                  <span className="block text-sm font-medium">
+                    {lang === 'en'
+                      ? 'Use proxy when starting the service'
+                      : '启动搜索服务时使用代理'}
+                  </span>
+                  <span className="block text-xs text-muted-foreground">
+                    {lang === 'en'
+                      ? 'One-click start injects USE_PROXY and PROXY_URL environment variables.'
+                      : '一键启动时会注入 USE_PROXY 和 PROXY_URL 环境变量。'}
+                  </span>
+                </span>
+              </label>
+
+              <div>
+                <label className="mb-2 block text-sm font-medium">
+                  {lang === 'en' ? 'Proxy URL' : '代理地址'}
+                </label>
+                <Input
+                  placeholder="http://127.0.0.1:7897"
+                  value={webSearchProxyUrl}
+                  onChange={(e) => setWebSearchProxyUrl(e.target.value)}
+                  disabled={!webSearchUseProxy}
+                />
+                <p className="mt-2 text-xs text-muted-foreground">
+                  {lang === 'en'
+                    ? 'When a VPN or proxy tool is enabled, such as Clash Verge, the web search service may need a local HTTP proxy port here.'
+                    : '开启 VPN 或代理工具时，例如使用 Clash Verge，联网搜索服务可能需要在这里填写本地 HTTP 代理端口。'}
+                </p>
+              </div>
+            </CardContent>
+          </Card>
+
+          <div className="flex flex-wrap justify-end gap-2">
+            <Button
+              variant="secondary"
+              onClick={() => {
+                void handleSaveWebSearch()
+              }}
+              disabled={webSearchBusy}
+            >
+              {lang === 'en' ? 'Save web search' : '保存联网搜索配置'}
+            </Button>
             <Button onClick={handleSaveTimeouts} disabled={savingTimeouts}>
               {savingTimeouts ? t('common.saving') : t('settings.saveTimeouts')}
             </Button>

--- a/src/renderer/src/store/sessionStore.ts
+++ b/src/renderer/src/store/sessionStore.ts
@@ -58,6 +58,7 @@ interface SessionStore {
     styleId: string
     pageCount?: number
     referenceDocumentPath?: string
+    allowWebSearch?: boolean
   }) => Promise<string>
   loadSession: (sessionId: string) => Promise<void>
   loadMessages: (payload: { sessionId: string; chatType: 'main' | 'page'; pageId?: string }) => Promise<void>

--- a/src/renderer/src/store/settingsStore.ts
+++ b/src/renderer/src/store/settingsStore.ts
@@ -1,12 +1,21 @@
 import { create } from 'zustand'
-import { ipc, type ModelConfig } from '@renderer/lib/ipc'
+import { ipc, type ModelConfig, type WebSearchServiceStatus } from '@renderer/lib/ipc'
 import type { ConfigurableModelTimeoutProfile } from '@shared/model-timeout.js'
+
+interface WebSearchSettings {
+  engines: string[]
+  limit: number
+  useProxy?: boolean
+  proxyUrl?: string
+  serviceStatus?: WebSearchServiceStatus
+}
 
 interface Settings {
   theme: string
   locale: 'zh' | 'en'
   storagePath: string
   timeouts: Record<ConfigurableModelTimeoutProfile, number>
+  webSearch?: WebSearchSettings
 }
 
 interface SettingsStore {
@@ -14,7 +23,9 @@ interface SettingsStore {
   modelConfigs: ModelConfig[]
   verificationMessage: string | null
   storagePathError: string | null
+  webSearchError: string | null
   loading: boolean
+  webSearchBusy: boolean
 
   fetchSettings: () => Promise<void>
   saveSettings: (settings: Partial<Settings>) => Promise<void>
@@ -38,6 +49,9 @@ interface SettingsStore {
     timeoutMs: number
   ) => Promise<boolean>
   chooseStoragePath: () => Promise<string | null>
+  refreshWebSearchServiceStatus: () => Promise<void>
+  installWebSearchService: () => Promise<boolean>
+  startWebSearchService: () => Promise<boolean>
 }
 
 const readStoredLocale = (): 'zh' | 'en' => {
@@ -52,7 +66,9 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
   modelConfigs: [],
   verificationMessage: null,
   storagePathError: null,
+  webSearchError: null,
   loading: false,
+  webSearchBusy: false,
 
   fetchSettings: async () => {
     try {
@@ -69,7 +85,8 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
         },
         modelConfigs: Array.isArray(modelConfigs) ? modelConfigs : [],
         storagePathError: null,
-        verificationMessage: null
+        verificationMessage: null,
+        webSearchError: null
       })
     } catch (error) {
       const message =
@@ -176,6 +193,99 @@ export const useSettingsStore = create<SettingsStore>((set, get) => ({
           : fallbackMessage('选择文件夹失败。', 'Failed to choose folder.')
       set({ storagePathError: message })
       return null
+    }
+  },
+
+  refreshWebSearchServiceStatus: async () => {
+    const settings = get().settings
+    if (!settings) return
+    try {
+      const serviceStatus = await ipc.getWebSearchServiceStatus()
+      set({
+        settings: {
+          ...settings,
+          webSearch: {
+            engines: settings.webSearch?.engines || ['bing', 'duckduckgo'],
+            limit: settings.webSearch?.limit || 20,
+            useProxy: settings.webSearch?.useProxy,
+            proxyUrl: settings.webSearch?.proxyUrl,
+            serviceStatus
+          }
+        },
+        webSearchError: null
+      })
+    } catch (error) {
+      const message =
+        error instanceof Error && error.message
+          ? error.message
+          : fallbackMessage('读取联网搜索服务状态失败。', 'Failed to load web search service status.')
+      set({ webSearchError: message })
+    }
+  },
+
+  installWebSearchService: async () => {
+    set({ webSearchBusy: true, webSearchError: null })
+    try {
+      const serviceStatus = await ipc.installWebSearchService()
+      const settings = get().settings
+      if (settings) {
+        set({
+          settings: {
+            ...settings,
+            webSearch: {
+              engines: settings.webSearch?.engines || ['bing', 'duckduckgo'],
+              limit: settings.webSearch?.limit || 20,
+              useProxy: settings.webSearch?.useProxy,
+              proxyUrl: settings.webSearch?.proxyUrl,
+              serviceStatus
+            }
+          },
+          webSearchBusy: false
+        })
+      } else {
+        set({ webSearchBusy: false })
+      }
+      return serviceStatus.installed
+    } catch (error) {
+      const message =
+        error instanceof Error && error.message
+          ? error.message
+          : fallbackMessage('安装联网搜索服务失败。', 'Failed to install web search service.')
+      set({ webSearchBusy: false, webSearchError: message })
+      return false
+    }
+  },
+
+  startWebSearchService: async () => {
+    set({ webSearchBusy: true, webSearchError: null })
+    try {
+      const serviceStatus = await ipc.startWebSearchService()
+      const settings = get().settings
+      if (settings) {
+        set({
+          settings: {
+            ...settings,
+            webSearch: {
+              engines: settings.webSearch?.engines || ['bing', 'duckduckgo'],
+              limit: settings.webSearch?.limit || 20,
+              useProxy: settings.webSearch?.useProxy,
+              proxyUrl: settings.webSearch?.proxyUrl,
+              serviceStatus
+            }
+          },
+          webSearchBusy: false
+        })
+      } else {
+        set({ webSearchBusy: false })
+      }
+      return serviceStatus.running
+    } catch (error) {
+      const message =
+        error instanceof Error && error.message
+          ? error.message
+          : fallbackMessage('启动联网搜索服务失败。', 'Failed to start web search service.')
+      set({ webSearchBusy: false, webSearchError: message })
+      return false
     }
   }
 }))


### PR DESCRIPTION
## 概述

本 PR 为 OhMyPPT 增加了可选的联网搜索能力，用于在用户明确开启后，为生成内容补充最新信息、公开网页内容与实时资料参考。

本功能基于开源项目 [open-websearch](https://github.com/Aas-ee/open-webSearch) 接入实现，通过本地服务方式为应用提供搜索与网页抓取能力。

## 本次改动

- 首页增加联网搜索开关
- 设置页增加联网搜索相关配置：
  - 服务状态检测
  - 一键安装
  - 一键启动
  - 代理配置
  - 搜索引擎选择
  - 搜索结果数量配置
- 主进程接入联网搜索服务管理能力
- 生成流程接入两个联网工具：
  - `web_search`
  - `fetch_web_content`
- Prompt 增强：
  - 仅在用户开启联网搜索时，才允许模型使用联网能力
  - 增加“先宽泛搜索，再按需细化搜索”的引导
  - 增加当前日期提示，减少模型生成过时信息的概率
  - 当搜索摘要不足时，引导模型继续调用 `fetch_web_content`
- 网页抓取失败时，增加 `markdown.new/...` 兜底抓取方式
- 退出应用时，自动停止应用托管启动的联网搜索服务

## 设计原则

- 联网搜索为可选能力，默认不强制启用
- 是否联网由用户决定，不由模型自行决定
- 搜索引擎和返回数量由设置统一控制，不交给模型选择
- 尽量复用现有生成链路和设置体系，减少对原有功能的影响

## 关于 open-websearch 集成方式

当前实现依赖本地 `open-websearch` 服务，不需要额外的搜索 API Key。  
应用会通过设置页对该服务进行状态检查，并支持一键安装与一键启动，尽量降低普通用户的使用门槛。

## 关于代理 / VPN 场景

在测试过程中，我们发现当用户开启 VPN 或本地代理软件时，`open-websearch` 可能出现搜索或抓取失败的问题。  
因此本 PR 增加了代理配置能力，允许用户在设置页中填写本地 HTTP 代理端口，以适配如 Clash Verge 等场景下的联网搜索服务启动与访问需求。

## 使用方式

1. 在设置页安装并启动本地 `open-websearch` 服务
2. 按需配置代理、搜索引擎和结果数量
3. 在首页开启“联网搜索”
4. 生成时，模型即可在需要最新信息时调用联网工具

## 已验证内容

- 设置页服务状态检测流程
- 一键安装 / 一键启动流程
- 联网搜索配置保存与读取
- 代理配置对服务启动参数的传递
- 生成流程在开启联网搜索后可调用搜索工具
- `fetch_web_content` 失败时可走 `markdown.new` 兜底
- `npm run typecheck:web`

## 说明

联网搜索能力仅在用户显式开启后生效，不会影响默认离线生成流程。  

## 效果预览
<img width="1500" height="1047" alt="image" src="https://github.com/user-attachments/assets/0accb893-ccc8-499e-8424-62f3f716af34" />

<img width="1651" height="916" alt="54be4208-438c-4219-9f4e-ec9bbe822867" src="https://github.com/user-attachments/assets/918bf60b-ac5d-45a3-bcc9-39600b50f193" />
