### PR TITLE
feat(export): add SMIL PPTX native animation writer

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,9 +5,8 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  '@langchain/core': ^1.1.46
+  '@langchain/core': ^1.1.47
   '@langchain/langgraph': ^1.3.0
-
 
 importers:
 
@@ -33,19 +32,22 @@ importers:
         version: 4.0.0(electron@39.8.8)
       '@joplin/turndown-plugin-gfm':
         specifier: ^1.0.64
-        version: 1.0.64
+        version: 1.0.67
       '@langchain/anthropic':
         specifier: ^1.3.29
-        version: 1.3.29(@langchain/core@1.1.46(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))
+        version: 1.3.29(@langchain/core@1.1.47(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))
       '@langchain/core':
-        specifier: ^1.1.46
-        version: 1.1.46(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
+        specifier: ^1.1.47
+        version: 1.1.47(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
+      '@langchain/google-genai':
+        specifier: ^2.1.31
+        version: 2.1.31(@langchain/core@1.1.47(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))
       '@langchain/langgraph':
         specifier: ^1.3.0
-        version: 1.3.0(@langchain/core@1.1.46(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)(zod@4.4.3)
+        version: 1.3.0(@langchain/core@1.1.47(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)(zod@4.4.3)
       '@langchain/openai':
         specifier: ^1.4.5
-        version: 1.4.5(@langchain/core@1.1.46(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(ws@8.20.0)
+        version: 1.4.5(@langchain/core@1.1.47(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(ws@8.20.0)
       '@libsql/client':
         specifier: ^0.14.0
         version: 0.14.0
@@ -108,13 +110,13 @@ importers:
         version: 0.44.7(@libsql/client@0.14.0)
       electron-log:
         specifier: ^5.4.3
-        version: 5.4.3
+        version: 5.4.4
       electron-updater:
         specifier: ^6.3.9
         version: 6.8.3
       fflate:
         specifier: ^0.8.2
-        version: 0.8.2
+        version: 0.8.3
       fonteditor-core:
         specifier: ^2.6.3
         version: 2.6.3
@@ -124,6 +126,12 @@ importers:
       katex:
         specifier: ^0.16.45
         version: 0.16.45
+      langchain:
+        specifier: ^1.4.1
+        version: 1.4.1(@langchain/core@1.1.47(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)
+      lru-cache:
+        specifier: ^11.5.0
+        version: 11.5.0
       lucide-react:
         specifier: ^0.574.0
         version: 0.574.0(react@19.2.5)
@@ -133,6 +141,9 @@ importers:
       nanoid:
         specifier: ^5.1.9
         version: 5.1.9
+      p-limit:
+        specifier: ^3.1.0
+        version: 3.1.0
       pdf-lib:
         specifier: ^1.17.1
         version: 1.17.1
@@ -221,6 +232,9 @@ importers:
       eslint-plugin-react-refresh:
         specifier: ^0.4.24
         version: 0.4.26(eslint@9.39.4(jiti@2.6.1))
+      happy-dom:
+        specifier: ^20.9.0
+        version: 20.9.0
       postcss:
         specifier: ^8.4.49
         version: 8.5.10
@@ -244,7 +258,7 @@ importers:
         version: 7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
       vitest:
         specifier: ^4.1.6
-        version: 4.1.7(@types/node@22.19.17)(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.6(@types/node@22.19.17)(happy-dom@20.9.0)(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
 
 packages:
 
@@ -976,6 +990,10 @@ packages:
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
 
+  '@google/generative-ai@0.24.1':
+    resolution: {integrity: sha512-MqO+MLfM6kjxcKoy0p1wRzG3b4ZZXtPI+z2IE26UogS2Cm/XHO+7gGRBh6gcJsOiIVoH93UwKvW4HdgiOZCy9Q==}
+    engines: {node: '>=18.0.0'}
+
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
     engines: {node: '>=18.18.0'}
@@ -1004,8 +1022,8 @@ packages:
     resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
     engines: {node: '>=18.0.0'}
 
-  '@joplin/turndown-plugin-gfm@1.0.64':
-    resolution: {integrity: sha512-8GJ7f9OenE3zkSVII5B6qzIkvgF7C/a20gaASEjM6jWPLPJFFQ2nQ3Ou/kXH1mPUTs9dC9VYs8QXVPvZabKXBQ==}
+  '@joplin/turndown-plugin-gfm@1.0.67':
+    resolution: {integrity: sha512-FZfW5EZfidhzd1IaY1uxHnIZPTVOxAdleMZ4/1U6Nt5b7+Qj5JThDnaIomuJtetnUBzuRNbe9FWMuqD4B3dlWA==}
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
@@ -1027,23 +1045,23 @@ packages:
     resolution: {integrity: sha512-ep1qBIcV07bajsg3fDqMd39rYwoRLOEK/6lk+MCxlm1YB5SRoKKJAZANrblQ/4RYhZJnxf95c6BSQu8VoNbVAQ==}
     engines: {node: '>=20'}
     peerDependencies:
-      '@langchain/core': ^1.1.45
+      '@langchain/core': ^1.1.46
 
-  '@langchain/core@1.1.46':
-    resolution: {integrity: sha512-i8rDC83BpItxChCw4Lf+6tAr+k+OUcbirc5ZkrhI9ywYWmvxegUljLGOGYvtJNTbEAIFkhYIODPE5QRqyjF6sA==}
+  '@langchain/core@1.1.47':
+    resolution: {integrity: sha512-+fiPu6ZFnJMrZyKeM77OIVPoMPAY6OKWacnPlojHtXTbMMzb2cEOKAJV0U07cDl86NHSCIYYa0i4CyKZzXbHQQ==}
     engines: {node: '>=20'}
 
-  '@langchain/langgraph-checkpoint@1.0.1':
-    resolution: {integrity: sha512-HM0cJLRpIsSlWBQ/xuDC67l52SqZ62Bh2Y61DX+Xorqwoh5e1KxYvfCD7GnSTbWWhjBOutvnR0vPhu4orFkZfw==}
-    engines: {node: '>=18'}
+  '@langchain/google-genai@2.1.31':
+    resolution: {integrity: sha512-lHIJGtZab0jqoufKRPXyHHg1nLXrE74LXd0ftgibWEACc1SpSLu6XwtA23+dX4l7Q/YeSgb9n40YJx5k00/fqw==}
+    engines: {node: '>=20'}
     peerDependencies:
-      '@langchain/core': ^1.0.1
+      '@langchain/core': ^1.1.46
 
   '@langchain/langgraph-checkpoint@1.0.2':
     resolution: {integrity: sha512-F4E5Tr0nt8FGghgdscJtHw+ABzChOHeI80R7Y1pjIHdiJom6c2ieo76vL+FWiny80JmoGqhrVAEIWrw0cXKPxg==}
     engines: {node: '>=18'}
     peerDependencies:
-      '@langchain/core': ^1.1.44
+      '@langchain/core': ^1.1.46
 
   '@langchain/langgraph-sdk@1.9.2':
     resolution: {integrity: sha512-1kDPjR0VH/39q2h8k0Sxi35KxOvEQPModVCepxGLlRkbZmuWUH+zfICuJd3rmD1ByeOKQBZEaB7Y+VCYmSMt1w==}
@@ -1066,7 +1084,7 @@ packages:
     resolution: {integrity: sha512-QvhTjiyqFPz81A+y6LHs223w6DTjv5+882DT4mup72bd72rRhNjTYo5fhes5um0swnKArvY/arc7KeFInfHHWw==}
     engines: {node: '>=18'}
     peerDependencies:
-      '@langchain/core': ^1.1.44
+      '@langchain/core': ^1.1.46
       zod: ^3.25.32 || ^4.2.0
       zod-to-json-schema: ^3.x
     peerDependenciesMeta:
@@ -1077,7 +1095,7 @@ packages:
     resolution: {integrity: sha512-bQ2WMIZfSh02trJLYSAtiIcD3j6EBCiAm9nw0dZWQsVaUxmWc3JJqs8uUte6AkMazmLHzcUIw+14UkXO5fRJvQ==}
     engines: {node: '>=20'}
     peerDependencies:
-      '@langchain/core': ^1.1.42
+      '@langchain/core': ^1.1.46
 
   '@langchain/protocol@0.0.15':
     resolution: {integrity: sha512-MllvbpMjqHevUm+v94M422mH7XKN+wGCvJRBVROTWBotEDOATYB4Ktk2UheYP859y9o2LlhtPek5t1T9eyfAbQ==}
@@ -2047,6 +2065,9 @@ packages:
   '@types/verror@1.10.11':
     resolution: {integrity: sha512-RlDm9K7+o5stv0Co8i8ZRGxDbrTxhJtgjqjFyVh/tXQyl/rYtTKlnTvZ88oSTeYREWurwx20Js4kTuKCsFkUtg==}
 
+  '@types/whatwg-mimetype@3.0.2':
+    resolution: {integrity: sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==}
+
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
@@ -2122,11 +2143,11 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
 
-  '@vitest/expect@4.1.7':
-    resolution: {integrity: sha512-1R+tw0ortHEbZDGMymm+pN7/AFQ/RkFFdtd7EN+VBpynKmLbP8A3rpEXdshBJ7+8hQ9zBJh/i1s0yKNtxAnU7w==}
+  '@vitest/expect@4.1.6':
+    resolution: {integrity: sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg==}
 
-  '@vitest/mocker@4.1.7':
-    resolution: {integrity: sha512-vY7nuamKgfvpA1Koa3oYIw/k7D6kZnpGyNMZW8loow2bsBYla1TFdqTaXncWdRn4pgwNs+90RhnXhJScDwQeJA==}
+  '@vitest/mocker@4.1.6':
+    resolution: {integrity: sha512-MCFc63czMjEInOlcY2cpQCvCN+KgbAn+60xu9cMgP4sKaLC5JNAKw7JH8QdAnoAC88hW1IiSNZ+GgVXlN1UcMQ==}
     peerDependencies:
       msw: ^2.4.9
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -2136,20 +2157,20 @@ packages:
       vite:
         optional: true
 
-  '@vitest/pretty-format@4.1.7':
-    resolution: {integrity: sha512-umgCarTOYQWIaDMvGDRZij+6b9oVeLIyJzfN+AS88e0ZOU3QTgNNSTtjQOpcvWr3np1N0j4WgZj+sb3oYBDscw==}
+  '@vitest/pretty-format@4.1.6':
+    resolution: {integrity: sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw==}
 
-  '@vitest/runner@4.1.7':
-    resolution: {integrity: sha512-BapjmAQ2aI78WdMEfeUWivnfVzB+VPGwWRQcJE0OUq7qEeEcBsCSf+0T5iREBNE5nBb4wA5Ya0W6IA+sghdEFw==}
+  '@vitest/runner@4.1.6':
+    resolution: {integrity: sha512-nOPCmn2+yD0ZNmKdsXGv/UxMMWbMuKeD6GyYncNwdkYDxpQvrPSKYj2rWuDjC2Y4b6w6hjip5dBKFzEUuZe3vA==}
 
-  '@vitest/snapshot@4.1.7':
-    resolution: {integrity: sha512-ZacLzja+TmJeZ1h14xW2FB/WpeimUD3haBXQPyJqxvo8jQTmfeA8zv58mtjN2C7EHXZDYVcVYdYmAxjkWVvKCw==}
+  '@vitest/snapshot@4.1.6':
+    resolution: {integrity: sha512-YhsdE6xAVfTDmzjxL2ZDUvjj+ZsgyOKe+TdQzqkD72wIOmHka8NuGQ6NpTNZv9D2Z63fbwWKJPeVpEw4EQgYxw==}
 
-  '@vitest/spy@4.1.7':
-    resolution: {integrity: sha512-kbkI5LMWakyuTIvs6fUJ5qdIVb1XVKsYJAT4OJ938cHMROYMSfmoQdZy0aaAnjbbc8F61vkoTqz/Az+/HiIu5Q==}
+  '@vitest/spy@4.1.6':
+    resolution: {integrity: sha512-JFKxMx6udhwKh/Ldo270e17QX710vgunMkuPAvXjHSvC6oqLWAHhVhjg/I71q0u0CBSErIODV1Kjv0FQNSWjdg==}
 
-  '@vitest/utils@4.1.7':
-    resolution: {integrity: sha512-T532WBu791cBxJlCl6SO+J14l81DQx6uQHm1bQbmCDY7nqlEIgkza/UFnSBNaUtSf41unldDFjdOBYEQC4b5Hw==}
+  '@vitest/utils@4.1.6':
+    resolution: {integrity: sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==}
 
   '@xmldom/xmldom@0.8.12':
     resolution: {integrity: sha512-9k/gHF6n/pAi/9tqr3m3aqkuiNosYTurLLUtc7xQ9sxB/wm7WPygCv8GYa6mS0fLJEHhqMC1ATYhz++U/lRHqg==}
@@ -2643,6 +2664,7 @@ packages:
     resolution: {integrity: sha512-ZdzmqwKmECOWJpqefloC5OJy1+WZBBse5+MR88z9g9Zn4VY+WYUkAyojmhzJckH5YbbZGcYIuGAkY5/Ys5OM2Q==}
     engines: {node: '>=8'}
     os: [darwin]
+    deprecated: 'Disk image license agreements are deprecated by Apple and will probably be removed in a future macOS release. Discussion at: https://github.com/argv-minus-one/dmg-license/issues/11'
     hasBin: true
 
   doctrine@2.1.0:
@@ -2789,8 +2811,8 @@ packages:
     engines: {node: '>=14.0.0'}
     hasBin: true
 
-  electron-log@5.4.3:
-    resolution: {integrity: sha512-sOUsM3LjZdugatazSQ/XTyNcw8dfvH1SYhXWiJyfYodAAKOZdHs0txPiLDXFzOZbhXgAgshQkshH2ccq0feyLQ==}
+  electron-log@5.4.4:
+    resolution: {integrity: sha512-istWgaXjBfURBSS8LWVW9C3jsc6+ac+tY1lXrQEOTp0lVj+a4OlO1Tmqb36GgnEUDv92DGC9VI1HNXwJinWpgA==}
     engines: {node: '>= 14'}
 
   electron-publish@26.8.1:
@@ -3078,8 +3100,8 @@ packages:
     resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
     engines: {node: ^12.20 || >= 14.13}
 
-  fflate@0.8.2:
-    resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
+  fflate@0.8.3:
+    resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
 
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
@@ -3215,9 +3237,13 @@ packages:
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
+  glob@7.2.0:
+    resolution: {integrity: sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    deprecated: Glob versions prior to v9 are no longer supported
 
   global-agent@3.0.0:
     resolution: {integrity: sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==}
@@ -3245,6 +3271,10 @@ packages:
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  happy-dom@20.9.0:
+    resolution: {integrity: sha512-GZZ9mKe8r646NUAf/zemnGbjYh4Bt8/MqASJY+pSm5ZDtc3YQox+4gsLI7yi1hba6o+eCsGxpHn5+iEVn31/FQ==}
+    engines: {node: '>=20.0.0'}
 
   has-bigints@1.1.0:
     resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
@@ -3596,7 +3626,13 @@ packages:
     resolution: {integrity: sha512-p3H5U1vfO0T4ri/xxqI6jccRP3LYmOW6KGxaJcwI5mIGVR/G6eNhZyjSZB9d7me6J7an4Pc6zA8tH8Qa6/7xwA==}
     engines: {node: '>=20'}
     peerDependencies:
-      '@langchain/core': ^1.1.44
+      '@langchain/core': ^1.1.46
+
+  langchain@1.4.1:
+    resolution: {integrity: sha512-LHGdj0OQV5pgyZgC2WWiEvNg5g16dg+c3j7pw7Iuw7tJXEvltNLVl6DjC6egxSsWT03FJN0eUJxJ13Dxhz2bBA==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@langchain/core': ^1.1.46
 
   langsmith@0.7.1:
     resolution: {integrity: sha512-Wjk90UjNoY5cBHMlNAC/eZx5clI8jnjBOBW8uJu8+MWBtx0QesNjsUiLtjI+I3UnrpxFFpDqGXcnhBjH654Mqg==}
@@ -3744,6 +3780,10 @@ packages:
 
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
+  lru-cache@11.5.0:
+    resolution: {integrity: sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA==}
+    engines: {node: 20 || >=22}
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
@@ -4963,20 +5003,20 @@ packages:
       yaml:
         optional: true
 
-  vitest@4.1.7:
-    resolution: {integrity: sha512-flYyaFd2CgoCoU+0UKt3pxksgC+S02iTDN0n3LtqaMeXsI9SBcdNujc2k0DeFLzUn/0k538yNjOSdwgCqcrwJA==}
+  vitest@4.1.6:
+    resolution: {integrity: sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==}
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@opentelemetry/api': ^1.9.0
       '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
-      '@vitest/browser-playwright': 4.1.7
-      '@vitest/browser-preview': 4.1.7
-      '@vitest/browser-webdriverio': 4.1.7
-      '@vitest/coverage-istanbul': 4.1.7
-      '@vitest/coverage-v8': 4.1.7
-      '@vitest/ui': 4.1.7
+      '@vitest/browser-playwright': 4.1.6
+      '@vitest/browser-preview': 4.1.6
+      '@vitest/browser-webdriverio': 4.1.6
+      '@vitest/coverage-istanbul': 4.1.6
+      '@vitest/coverage-v8': 4.1.6
+      '@vitest/ui': 4.1.6
       happy-dom: '*'
       jsdom: '*'
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -5015,6 +5055,10 @@ packages:
     resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
     engines: {node: '>=18'}
     deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
+
+  whatwg-mimetype@3.0.0:
+    resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
+    engines: {node: '>=12'}
 
   whatwg-mimetype@4.0.0:
     resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
@@ -5767,6 +5811,8 @@ snapshots:
 
   '@floating-ui/utils@0.2.11': {}
 
+  '@google/generative-ai@0.24.1': {}
+
   '@humanfs/core@0.19.2':
     dependencies:
       '@humanfs/types': 0.15.0
@@ -5796,7 +5842,7 @@ snapshots:
     dependencies:
       minipass: 7.1.3
 
-  '@joplin/turndown-plugin-gfm@1.0.64': {}
+  '@joplin/turndown-plugin-gfm@1.0.67': {}
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -5817,13 +5863,13 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@langchain/anthropic@1.3.29(@langchain/core@1.1.46(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))':
+  '@langchain/anthropic@1.3.29(@langchain/core@1.1.47(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))':
     dependencies:
       '@anthropic-ai/sdk': 0.91.1(zod@3.25.76)
-      '@langchain/core': 1.1.46(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
+      '@langchain/core': 1.1.47(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
       zod: 3.25.76
 
-  '@langchain/core@1.1.46(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)':
+  '@langchain/core@1.1.47(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)':
     dependencies:
       '@cfworker/json-schema': 4.1.1
       '@standard-schema/spec': 1.1.0
@@ -5831,7 +5877,7 @@ snapshots:
       langsmith: 0.7.1(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
       mustache: 4.2.0
       p-queue: 6.6.2
-      zod: 3.25.76
+      zod: 4.4.3
     transitivePeerDependencies:
       - '@opentelemetry/api'
       - '@opentelemetry/exporter-trace-otlp-proto'
@@ -5839,19 +5885,19 @@ snapshots:
       - openai
       - ws
 
-  '@langchain/langgraph-checkpoint@1.0.1(@langchain/core@1.1.46(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))':
+  '@langchain/google-genai@2.1.31(@langchain/core@1.1.47(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))':
     dependencies:
-      '@langchain/core': 1.1.46(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
-      uuid: 10.0.0
+      '@google/generative-ai': 0.24.1
+      '@langchain/core': 1.1.47(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
 
-  '@langchain/langgraph-checkpoint@1.0.2(@langchain/core@1.1.46(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))':
+  '@langchain/langgraph-checkpoint@1.0.2(@langchain/core@1.1.47(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))':
     dependencies:
-      '@langchain/core': 1.1.46(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
+      '@langchain/core': 1.1.47(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
       uuid: 10.0.0
 
   '@langchain/langgraph-sdk@1.9.2(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)':
     dependencies:
-      '@langchain/core': 1.1.46(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
+      '@langchain/core': 1.1.47(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
       '@langchain/protocol': 0.0.15
       '@types/json-schema': 7.0.15
       p-queue: 9.1.2
@@ -5867,30 +5913,10 @@ snapshots:
       - openai
       - ws
 
-  '@langchain/langgraph@1.3.0(@langchain/core@1.1.46(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)(zod@3.25.76)':
+  '@langchain/langgraph@1.3.0(@langchain/core@1.1.47(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)(zod@4.4.3)':
     dependencies:
-      '@langchain/core': 1.1.46(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
-      '@langchain/langgraph-checkpoint': 1.0.2(@langchain/core@1.1.46(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))
-      '@langchain/langgraph-sdk': 1.9.2(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)
-      '@langchain/protocol': 0.0.15
-      '@standard-schema/spec': 1.1.0
-      uuid: 10.0.0
-      zod: 3.25.76
-    transitivePeerDependencies:
-      - '@opentelemetry/api'
-      - '@opentelemetry/exporter-trace-otlp-proto'
-      - '@opentelemetry/sdk-trace-base'
-      - openai
-      - react
-      - react-dom
-      - svelte
-      - vue
-      - ws
-
-  '@langchain/langgraph@1.3.0(@langchain/core@1.1.46(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)(zod@4.4.3)':
-    dependencies:
-      '@langchain/core': 1.1.46(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
-      '@langchain/langgraph-checkpoint': 1.0.2(@langchain/core@1.1.46(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))
+      '@langchain/core': 1.1.47(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
+      '@langchain/langgraph-checkpoint': 1.0.2(@langchain/core@1.1.47(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))
       '@langchain/langgraph-sdk': 1.9.2(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)
       '@langchain/protocol': 0.0.15
       '@standard-schema/spec': 1.1.0
@@ -5907,9 +5933,9 @@ snapshots:
       - vue
       - ws
 
-  '@langchain/openai@1.4.5(@langchain/core@1.1.46(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(ws@8.20.0)':
+  '@langchain/openai@1.4.5(@langchain/core@1.1.47(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(ws@8.20.0)':
     dependencies:
-      '@langchain/core': 1.1.46(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
+      '@langchain/core': 1.1.47(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
       js-tiktoken: 1.0.21
       openai: 6.34.0(ws@8.20.0)(zod@3.25.76)
       zod: 3.25.76
@@ -6811,6 +6837,8 @@ snapshots:
   '@types/verror@1.10.11':
     optional: true
 
+  '@types/whatwg-mimetype@3.0.2': {}
+
   '@types/ws@8.18.1':
     dependencies:
       '@types/node': 22.19.17
@@ -6925,44 +6953,44 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/expect@4.1.7':
+  '@vitest/expect@4.1.6':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
-      '@vitest/spy': 4.1.7
-      '@vitest/utils': 4.1.7
+      '@vitest/spy': 4.1.6
+      '@vitest/utils': 4.1.6
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.7(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))':
+  '@vitest/mocker@4.1.6(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
-      '@vitest/spy': 4.1.7
+      '@vitest/spy': 4.1.6
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       vite: 7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
 
-  '@vitest/pretty-format@4.1.7':
+  '@vitest/pretty-format@4.1.6':
     dependencies:
       tinyrainbow: 3.1.0
 
-  '@vitest/runner@4.1.7':
+  '@vitest/runner@4.1.6':
     dependencies:
-      '@vitest/utils': 4.1.7
+      '@vitest/utils': 4.1.6
       pathe: 2.0.3
 
-  '@vitest/snapshot@4.1.7':
+  '@vitest/snapshot@4.1.6':
     dependencies:
-      '@vitest/pretty-format': 4.1.7
-      '@vitest/utils': 4.1.7
+      '@vitest/pretty-format': 4.1.6
+      '@vitest/utils': 4.1.6
       magic-string: 0.30.21
       pathe: 2.0.3
 
-  '@vitest/spy@4.1.7': {}
+  '@vitest/spy@4.1.6': {}
 
-  '@vitest/utils@4.1.7':
+  '@vitest/utils@4.1.6':
     dependencies:
-      '@vitest/pretty-format': 4.1.7
+      '@vitest/pretty-format': 4.1.6
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
@@ -7463,11 +7491,11 @@ snapshots:
 
   deepagents@1.10.2(langsmith@0.7.1(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0):
     dependencies:
-      '@langchain/core': 1.1.46(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
-      '@langchain/langgraph': 1.3.0(@langchain/core@1.1.46(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)(zod@4.4.3)
+      '@langchain/core': 1.1.47(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
+      '@langchain/langgraph': 1.3.0(@langchain/core@1.1.47(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)(zod@4.4.3)
       '@langchain/langgraph-sdk': 1.9.2(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)
       fast-glob: 3.3.3
-      langchain: 1.4.0(@langchain/core@1.1.46(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)
+      langchain: 1.4.0(@langchain/core@1.1.47(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)
       langsmith: 0.7.1(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
       micromatch: 4.0.8
       yaml: 2.8.3
@@ -7633,7 +7661,7 @@ snapshots:
       - electron-builder-squirrel-windows
       - supports-color
 
-  electron-log@5.4.3: {}
+  electron-log@5.4.4: {}
 
   electron-publish@26.8.1:
     dependencies:
@@ -8107,7 +8135,7 @@ snapshots:
       node-domexception: 1.0.0
       web-streams-polyfill: 3.3.3
 
-  fflate@0.8.2: {}
+  fflate@0.8.3: {}
 
   file-entry-cache@8.0.0:
     dependencies:
@@ -8270,6 +8298,15 @@ snapshots:
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
 
+  glob@7.2.0:
+    dependencies:
+      fs.realpath: 1.0.0
+      inflight: 1.0.6
+      inherits: 2.0.4
+      minimatch: 3.1.5
+      once: 1.4.0
+      path-is-absolute: 1.0.1
+
   glob@7.2.3:
     dependencies:
       fs.realpath: 1.0.0
@@ -8315,6 +8352,18 @@ snapshots:
       responselike: 2.0.1
 
   graceful-fs@4.2.11: {}
+
+  happy-dom@20.9.0:
+    dependencies:
+      '@types/node': 22.19.17
+      '@types/whatwg-mimetype': 3.0.2
+      '@types/ws': 8.18.1
+      entities: 7.0.1
+      whatwg-mimetype: 3.0.0
+      ws: 8.20.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   has-bigints@1.1.0: {}
 
@@ -8684,13 +8733,32 @@ snapshots:
     dependencies:
       json-buffer: 3.0.1
 
-  langchain@1.4.0(@langchain/core@1.1.46(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0):
+  langchain@1.4.0(@langchain/core@1.1.47(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0):
     dependencies:
-      '@langchain/core': 1.1.46(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
-      '@langchain/langgraph': 1.3.0(@langchain/core@1.1.46(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)(zod@3.25.76)
-      '@langchain/langgraph-checkpoint': 1.0.1(@langchain/core@1.1.46(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))
+      '@langchain/core': 1.1.47(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
+      '@langchain/langgraph': 1.3.0(@langchain/core@1.1.47(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)(zod@4.4.3)
+      '@langchain/langgraph-checkpoint': 1.0.2(@langchain/core@1.1.47(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))
       langsmith: 0.7.1(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
-      zod: 3.25.76
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - '@opentelemetry/exporter-trace-otlp-proto'
+      - '@opentelemetry/sdk-trace-base'
+      - openai
+      - react
+      - react-dom
+      - svelte
+      - vue
+      - ws
+      - zod-to-json-schema
+
+  langchain@1.4.1(@langchain/core@1.1.47(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0):
+    dependencies:
+      '@langchain/core': 1.1.47(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
+      '@langchain/langgraph': 1.3.0(@langchain/core@1.1.47(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)(zod@4.4.3)
+      '@langchain/langgraph-checkpoint': 1.0.2(@langchain/core@1.1.47(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))
+      langsmith: 0.7.1(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
+      zod: 4.4.3
     transitivePeerDependencies:
       - '@opentelemetry/api'
       - '@opentelemetry/exporter-trace-otlp-proto'
@@ -8815,6 +8883,8 @@ snapshots:
   lowercase-keys@2.0.0: {}
 
   lru-cache@10.4.3: {}
+
+  lru-cache@11.5.0: {}
 
   lru-cache@5.1.1:
     dependencies:
@@ -9674,7 +9744,7 @@ snapshots:
 
   rimraf@2.6.3:
     dependencies:
-      glob: 7.2.3
+      glob: 7.2.0
 
   roarr@2.15.4:
     dependencies:
@@ -10289,15 +10359,15 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.8.3
 
-  vitest@4.1.7(@types/node@22.19.17)(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)):
+  vitest@4.1.6(@types/node@22.19.17)(happy-dom@20.9.0)(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
-      '@vitest/expect': 4.1.7
-      '@vitest/mocker': 4.1.7(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
-      '@vitest/pretty-format': 4.1.7
-      '@vitest/runner': 4.1.7
-      '@vitest/snapshot': 4.1.7
-      '@vitest/spy': 4.1.7
-      '@vitest/utils': 4.1.7
+      '@vitest/expect': 4.1.6
+      '@vitest/mocker': 4.1.6(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/pretty-format': 4.1.6
+      '@vitest/runner': 4.1.6
+      '@vitest/snapshot': 4.1.6
+      '@vitest/spy': 4.1.6
+      '@vitest/utils': 4.1.6
       es-module-lexer: 2.1.0
       expect-type: 1.3.0
       magic-string: 0.30.21
@@ -10313,6 +10383,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.19.17
+      happy-dom: 20.9.0
     transitivePeerDependencies:
       - msw
 
@@ -10325,6 +10396,8 @@ snapshots:
   whatwg-encoding@3.1.1:
     dependencies:
       iconv-lite: 0.6.3
+
+  whatwg-mimetype@3.0.0: {}
 
   whatwg-mimetype@4.0.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,7 @@ overrides:
   '@langchain/core': ^1.1.46
   '@langchain/langgraph': ^1.3.0
 
+
 importers:
 
   .:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,10 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-overrides:
-  '@langchain/core': ^1.1.47
-  '@langchain/langgraph': ^1.3.0
-
 importers:
 
   .:
@@ -32,22 +28,22 @@ importers:
         version: 4.0.0(electron@39.8.8)
       '@joplin/turndown-plugin-gfm':
         specifier: ^1.0.64
-        version: 1.0.67
+        version: 1.0.64
       '@langchain/anthropic':
         specifier: ^1.3.29
-        version: 1.3.29(@langchain/core@1.1.47(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))
+        version: 1.3.29(@langchain/core@1.1.48(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))
       '@langchain/core':
         specifier: ^1.1.47
-        version: 1.1.47(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
+        version: 1.1.48(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
       '@langchain/google-genai':
         specifier: ^2.1.31
-        version: 2.1.31(@langchain/core@1.1.47(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))
+        version: 2.1.31(@langchain/core@1.1.48(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))
       '@langchain/langgraph':
         specifier: ^1.3.0
-        version: 1.3.0(@langchain/core@1.1.47(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)(zod@4.4.3)
+        version: 1.3.0(@langchain/core@1.1.48(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)(zod@4.4.3)
       '@langchain/openai':
         specifier: ^1.4.5
-        version: 1.4.5(@langchain/core@1.1.47(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(ws@8.20.0)
+        version: 1.4.5(@langchain/core@1.1.48(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(ws@8.20.0)
       '@libsql/client':
         specifier: ^0.14.0
         version: 0.14.0
@@ -110,13 +106,13 @@ importers:
         version: 0.44.7(@libsql/client@0.14.0)
       electron-log:
         specifier: ^5.4.3
-        version: 5.4.4
+        version: 5.4.3
       electron-updater:
         specifier: ^6.3.9
         version: 6.8.3
       fflate:
         specifier: ^0.8.2
-        version: 0.8.3
+        version: 0.8.2
       fonteditor-core:
         specifier: ^2.6.3
         version: 2.6.3
@@ -128,7 +124,7 @@ importers:
         version: 0.16.45
       langchain:
         specifier: ^1.4.1
-        version: 1.4.1(@langchain/core@1.1.47(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)
+        version: 1.4.2(@langchain/core@1.1.48(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)
       lru-cache:
         specifier: ^11.5.0
         version: 11.5.0
@@ -1022,8 +1018,8 @@ packages:
     resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
     engines: {node: '>=18.0.0'}
 
-  '@joplin/turndown-plugin-gfm@1.0.67':
-    resolution: {integrity: sha512-FZfW5EZfidhzd1IaY1uxHnIZPTVOxAdleMZ4/1U6Nt5b7+Qj5JThDnaIomuJtetnUBzuRNbe9FWMuqD4B3dlWA==}
+  '@joplin/turndown-plugin-gfm@1.0.64':
+    resolution: {integrity: sha512-8GJ7f9OenE3zkSVII5B6qzIkvgF7C/a20gaASEjM6jWPLPJFFQ2nQ3Ou/kXH1mPUTs9dC9VYs8QXVPvZabKXBQ==}
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
@@ -1045,23 +1041,33 @@ packages:
     resolution: {integrity: sha512-ep1qBIcV07bajsg3fDqMd39rYwoRLOEK/6lk+MCxlm1YB5SRoKKJAZANrblQ/4RYhZJnxf95c6BSQu8VoNbVAQ==}
     engines: {node: '>=20'}
     peerDependencies:
-      '@langchain/core': ^1.1.46
+      '@langchain/core': ^1.1.45
 
-  '@langchain/core@1.1.47':
-    resolution: {integrity: sha512-+fiPu6ZFnJMrZyKeM77OIVPoMPAY6OKWacnPlojHtXTbMMzb2cEOKAJV0U07cDl86NHSCIYYa0i4CyKZzXbHQQ==}
+  '@langchain/core@1.1.46':
+    resolution: {integrity: sha512-i8rDC83BpItxChCw4Lf+6tAr+k+OUcbirc5ZkrhI9ywYWmvxegUljLGOGYvtJNTbEAIFkhYIODPE5QRqyjF6sA==}
+    engines: {node: '>=20'}
+
+  '@langchain/core@1.1.48':
+    resolution: {integrity: sha512-fQU6Guyb1pwc2fEplmA8FPbKfOMAofjnyJzExevro0FxEiuGHE18Ov/ZHmT9trWCDTZRI9eW1VIc6aChxV8pAQ==}
     engines: {node: '>=20'}
 
   '@langchain/google-genai@2.1.31':
     resolution: {integrity: sha512-lHIJGtZab0jqoufKRPXyHHg1nLXrE74LXd0ftgibWEACc1SpSLu6XwtA23+dX4l7Q/YeSgb9n40YJx5k00/fqw==}
     engines: {node: '>=20'}
     peerDependencies:
-      '@langchain/core': ^1.1.46
+      '@langchain/core': ^1.1.47
+
+  '@langchain/langgraph-checkpoint@1.0.1':
+    resolution: {integrity: sha512-HM0cJLRpIsSlWBQ/xuDC67l52SqZ62Bh2Y61DX+Xorqwoh5e1KxYvfCD7GnSTbWWhjBOutvnR0vPhu4orFkZfw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@langchain/core': ^1.0.1
 
   '@langchain/langgraph-checkpoint@1.0.2':
     resolution: {integrity: sha512-F4E5Tr0nt8FGghgdscJtHw+ABzChOHeI80R7Y1pjIHdiJom6c2ieo76vL+FWiny80JmoGqhrVAEIWrw0cXKPxg==}
     engines: {node: '>=18'}
     peerDependencies:
-      '@langchain/core': ^1.1.46
+      '@langchain/core': ^1.1.44
 
   '@langchain/langgraph-sdk@1.9.2':
     resolution: {integrity: sha512-1kDPjR0VH/39q2h8k0Sxi35KxOvEQPModVCepxGLlRkbZmuWUH+zfICuJd3rmD1ByeOKQBZEaB7Y+VCYmSMt1w==}
@@ -1080,11 +1086,40 @@ packages:
       vue:
         optional: true
 
+  '@langchain/langgraph-sdk@1.9.5':
+    resolution: {integrity: sha512-NMcz1rEKuVz07ZqcSzNJZCZR9FppRNh+/YWjCKtwZ7a/WNytDEAh26qXTtmDQZ7+J+1nEXhHym1wZDrOxA99wg==}
+    peerDependencies:
+      '@langchain/core': ^1.1.44
+      react: ^18 || ^19
+      react-dom: ^18 || ^19
+      svelte: ^4.0.0 || ^5.0.0
+      vue: ^3.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
+
   '@langchain/langgraph@1.3.0':
     resolution: {integrity: sha512-QvhTjiyqFPz81A+y6LHs223w6DTjv5+882DT4mup72bd72rRhNjTYo5fhes5um0swnKArvY/arc7KeFInfHHWw==}
     engines: {node: '>=18'}
     peerDependencies:
-      '@langchain/core': ^1.1.46
+      '@langchain/core': ^1.1.44
+      zod: ^3.25.32 || ^4.2.0
+      zod-to-json-schema: ^3.x
+    peerDependenciesMeta:
+      zod-to-json-schema:
+        optional: true
+
+  '@langchain/langgraph@1.3.2':
+    resolution: {integrity: sha512-SL7Ktsr681R7da+1b2MVOWEbaCoFJOXEJPTGOjg4JIG4C7quWbTYC8DzxhcCxte6D/8cGp0rYDBnbKLXEpNqlA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@langchain/core': ^1.1.44
       zod: ^3.25.32 || ^4.2.0
       zod-to-json-schema: ^3.x
     peerDependenciesMeta:
@@ -1095,7 +1130,7 @@ packages:
     resolution: {integrity: sha512-bQ2WMIZfSh02trJLYSAtiIcD3j6EBCiAm9nw0dZWQsVaUxmWc3JJqs8uUte6AkMazmLHzcUIw+14UkXO5fRJvQ==}
     engines: {node: '>=20'}
     peerDependencies:
-      '@langchain/core': ^1.1.46
+      '@langchain/core': ^1.1.42
 
   '@langchain/protocol@0.0.15':
     resolution: {integrity: sha512-MllvbpMjqHevUm+v94M422mH7XKN+wGCvJRBVROTWBotEDOATYB4Ktk2UheYP859y9o2LlhtPek5t1T9eyfAbQ==}
@@ -2664,7 +2699,6 @@ packages:
     resolution: {integrity: sha512-ZdzmqwKmECOWJpqefloC5OJy1+WZBBse5+MR88z9g9Zn4VY+WYUkAyojmhzJckH5YbbZGcYIuGAkY5/Ys5OM2Q==}
     engines: {node: '>=8'}
     os: [darwin]
-    deprecated: 'Disk image license agreements are deprecated by Apple and will probably be removed in a future macOS release. Discussion at: https://github.com/argv-minus-one/dmg-license/issues/11'
     hasBin: true
 
   doctrine@2.1.0:
@@ -2811,8 +2845,8 @@ packages:
     engines: {node: '>=14.0.0'}
     hasBin: true
 
-  electron-log@5.4.4:
-    resolution: {integrity: sha512-istWgaXjBfURBSS8LWVW9C3jsc6+ac+tY1lXrQEOTp0lVj+a4OlO1Tmqb36GgnEUDv92DGC9VI1HNXwJinWpgA==}
+  electron-log@5.4.3:
+    resolution: {integrity: sha512-sOUsM3LjZdugatazSQ/XTyNcw8dfvH1SYhXWiJyfYodAAKOZdHs0txPiLDXFzOZbhXgAgshQkshH2ccq0feyLQ==}
     engines: {node: '>= 14'}
 
   electron-publish@26.8.1:
@@ -3100,8 +3134,8 @@ packages:
     resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
     engines: {node: ^12.20 || >= 14.13}
 
-  fflate@0.8.3:
-    resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
+  fflate@0.8.2:
+    resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
 
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
@@ -3237,13 +3271,9 @@ packages:
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
-  glob@7.2.0:
-    resolution: {integrity: sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==}
-    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
-
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   global-agent@3.0.0:
     resolution: {integrity: sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==}
@@ -3626,13 +3656,13 @@ packages:
     resolution: {integrity: sha512-p3H5U1vfO0T4ri/xxqI6jccRP3LYmOW6KGxaJcwI5mIGVR/G6eNhZyjSZB9d7me6J7an4Pc6zA8tH8Qa6/7xwA==}
     engines: {node: '>=20'}
     peerDependencies:
-      '@langchain/core': ^1.1.46
+      '@langchain/core': ^1.1.44
 
-  langchain@1.4.1:
-    resolution: {integrity: sha512-LHGdj0OQV5pgyZgC2WWiEvNg5g16dg+c3j7pw7Iuw7tJXEvltNLVl6DjC6egxSsWT03FJN0eUJxJ13Dxhz2bBA==}
+  langchain@1.4.2:
+    resolution: {integrity: sha512-SLGipy0r4nqQD0aiUOBYLMeGFfB/QiYnMndfZ8sGN89vXDCIXbYqcE7G/4QDDX3nZsM7/emQpoScmlxEX6sDnQ==}
     engines: {node: '>=20'}
     peerDependencies:
-      '@langchain/core': ^1.1.46
+      '@langchain/core': ^1.1.48
 
   langsmith@0.7.1:
     resolution: {integrity: sha512-Wjk90UjNoY5cBHMlNAC/eZx5clI8jnjBOBW8uJu8+MWBtx0QesNjsUiLtjI+I3UnrpxFFpDqGXcnhBjH654Mqg==}
@@ -5842,7 +5872,7 @@ snapshots:
     dependencies:
       minipass: 7.1.3
 
-  '@joplin/turndown-plugin-gfm@1.0.67': {}
+  '@joplin/turndown-plugin-gfm@1.0.64': {}
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -5863,13 +5893,29 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@langchain/anthropic@1.3.29(@langchain/core@1.1.47(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))':
+  '@langchain/anthropic@1.3.29(@langchain/core@1.1.48(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))':
     dependencies:
       '@anthropic-ai/sdk': 0.91.1(zod@3.25.76)
-      '@langchain/core': 1.1.47(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
+      '@langchain/core': 1.1.48(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
       zod: 3.25.76
 
-  '@langchain/core@1.1.47(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)':
+  '@langchain/core@1.1.46(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)':
+    dependencies:
+      '@cfworker/json-schema': 4.1.1
+      '@standard-schema/spec': 1.1.0
+      js-tiktoken: 1.0.21
+      langsmith: 0.7.1(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
+      mustache: 4.2.0
+      p-queue: 6.6.2
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - '@opentelemetry/exporter-trace-otlp-proto'
+      - '@opentelemetry/sdk-trace-base'
+      - openai
+      - ws
+
+  '@langchain/core@1.1.48(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)':
     dependencies:
       '@cfworker/json-schema': 4.1.1
       '@standard-schema/spec': 1.1.0
@@ -5885,19 +5931,29 @@ snapshots:
       - openai
       - ws
 
-  '@langchain/google-genai@2.1.31(@langchain/core@1.1.47(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))':
+  '@langchain/google-genai@2.1.31(@langchain/core@1.1.48(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))':
     dependencies:
       '@google/generative-ai': 0.24.1
-      '@langchain/core': 1.1.47(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
+      '@langchain/core': 1.1.48(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
 
-  '@langchain/langgraph-checkpoint@1.0.2(@langchain/core@1.1.47(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))':
+  '@langchain/langgraph-checkpoint@1.0.1(@langchain/core@1.1.46(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))':
     dependencies:
-      '@langchain/core': 1.1.47(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
+      '@langchain/core': 1.1.46(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
+      uuid: 10.0.0
+
+  '@langchain/langgraph-checkpoint@1.0.2(@langchain/core@1.1.46(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))':
+    dependencies:
+      '@langchain/core': 1.1.46(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
+      uuid: 10.0.0
+
+  '@langchain/langgraph-checkpoint@1.0.2(@langchain/core@1.1.48(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))':
+    dependencies:
+      '@langchain/core': 1.1.48(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
       uuid: 10.0.0
 
   '@langchain/langgraph-sdk@1.9.2(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)':
     dependencies:
-      '@langchain/core': 1.1.47(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
+      '@langchain/core': 1.1.46(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
       '@langchain/protocol': 0.0.15
       '@types/json-schema': 7.0.15
       p-queue: 9.1.2
@@ -5913,10 +5969,42 @@ snapshots:
       - openai
       - ws
 
-  '@langchain/langgraph@1.3.0(@langchain/core@1.1.47(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)(zod@4.4.3)':
+  '@langchain/langgraph-sdk@1.9.5(@langchain/core@1.1.48(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
-      '@langchain/core': 1.1.47(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
-      '@langchain/langgraph-checkpoint': 1.0.2(@langchain/core@1.1.47(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))
+      '@langchain/core': 1.1.48(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
+      '@langchain/protocol': 0.0.15
+      '@types/json-schema': 7.0.15
+      p-queue: 9.1.2
+      p-retry: 7.1.1
+      uuid: 13.0.0
+    optionalDependencies:
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+
+  '@langchain/langgraph@1.3.0(@langchain/core@1.1.46(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)(zod@3.25.76)':
+    dependencies:
+      '@langchain/core': 1.1.46(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
+      '@langchain/langgraph-checkpoint': 1.0.2(@langchain/core@1.1.46(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))
+      '@langchain/langgraph-sdk': 1.9.2(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)
+      '@langchain/protocol': 0.0.15
+      '@standard-schema/spec': 1.1.0
+      uuid: 10.0.0
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - '@opentelemetry/exporter-trace-otlp-proto'
+      - '@opentelemetry/sdk-trace-base'
+      - openai
+      - react
+      - react-dom
+      - svelte
+      - vue
+      - ws
+
+  '@langchain/langgraph@1.3.0(@langchain/core@1.1.46(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)(zod@4.4.3)':
+    dependencies:
+      '@langchain/core': 1.1.46(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
+      '@langchain/langgraph-checkpoint': 1.0.2(@langchain/core@1.1.46(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))
       '@langchain/langgraph-sdk': 1.9.2(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)
       '@langchain/protocol': 0.0.15
       '@standard-schema/spec': 1.1.0
@@ -5933,9 +6021,44 @@ snapshots:
       - vue
       - ws
 
-  '@langchain/openai@1.4.5(@langchain/core@1.1.47(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(ws@8.20.0)':
+  '@langchain/langgraph@1.3.0(@langchain/core@1.1.48(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)(zod@4.4.3)':
     dependencies:
-      '@langchain/core': 1.1.47(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
+      '@langchain/core': 1.1.48(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
+      '@langchain/langgraph-checkpoint': 1.0.2(@langchain/core@1.1.48(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))
+      '@langchain/langgraph-sdk': 1.9.2(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)
+      '@langchain/protocol': 0.0.15
+      '@standard-schema/spec': 1.1.0
+      uuid: 10.0.0
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - '@opentelemetry/exporter-trace-otlp-proto'
+      - '@opentelemetry/sdk-trace-base'
+      - openai
+      - react
+      - react-dom
+      - svelte
+      - vue
+      - ws
+
+  '@langchain/langgraph@1.3.2(@langchain/core@1.1.48(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod@4.4.3)':
+    dependencies:
+      '@langchain/core': 1.1.48(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
+      '@langchain/langgraph-checkpoint': 1.0.2(@langchain/core@1.1.48(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))
+      '@langchain/langgraph-sdk': 1.9.5(@langchain/core@1.1.48(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@langchain/protocol': 0.0.15
+      '@standard-schema/spec': 1.1.0
+      uuid: 10.0.0
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - react
+      - react-dom
+      - svelte
+      - vue
+
+  '@langchain/openai@1.4.5(@langchain/core@1.1.48(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(ws@8.20.0)':
+    dependencies:
+      '@langchain/core': 1.1.48(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
       js-tiktoken: 1.0.21
       openai: 6.34.0(ws@8.20.0)(zod@3.25.76)
       zod: 3.25.76
@@ -7491,11 +7614,11 @@ snapshots:
 
   deepagents@1.10.2(langsmith@0.7.1(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0):
     dependencies:
-      '@langchain/core': 1.1.47(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
-      '@langchain/langgraph': 1.3.0(@langchain/core@1.1.47(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)(zod@4.4.3)
+      '@langchain/core': 1.1.46(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
+      '@langchain/langgraph': 1.3.0(@langchain/core@1.1.46(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)(zod@4.4.3)
       '@langchain/langgraph-sdk': 1.9.2(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)
       fast-glob: 3.3.3
-      langchain: 1.4.0(@langchain/core@1.1.47(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)
+      langchain: 1.4.0(@langchain/core@1.1.46(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)
       langsmith: 0.7.1(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
       micromatch: 4.0.8
       yaml: 2.8.3
@@ -7661,7 +7784,7 @@ snapshots:
       - electron-builder-squirrel-windows
       - supports-color
 
-  electron-log@5.4.4: {}
+  electron-log@5.4.3: {}
 
   electron-publish@26.8.1:
     dependencies:
@@ -8135,7 +8258,7 @@ snapshots:
       node-domexception: 1.0.0
       web-streams-polyfill: 3.3.3
 
-  fflate@0.8.3: {}
+  fflate@0.8.2: {}
 
   file-entry-cache@8.0.0:
     dependencies:
@@ -8297,15 +8420,6 @@ snapshots:
       minipass: 7.1.3
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
-
-  glob@7.2.0:
-    dependencies:
-      fs.realpath: 1.0.0
-      inflight: 1.0.6
-      inherits: 2.0.4
-      minimatch: 3.1.5
-      once: 1.4.0
-      path-is-absolute: 1.0.1
 
   glob@7.2.3:
     dependencies:
@@ -8733,13 +8847,13 @@ snapshots:
     dependencies:
       json-buffer: 3.0.1
 
-  langchain@1.4.0(@langchain/core@1.1.47(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0):
+  langchain@1.4.0(@langchain/core@1.1.46(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0):
     dependencies:
-      '@langchain/core': 1.1.47(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
-      '@langchain/langgraph': 1.3.0(@langchain/core@1.1.47(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)(zod@4.4.3)
-      '@langchain/langgraph-checkpoint': 1.0.2(@langchain/core@1.1.47(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))
+      '@langchain/core': 1.1.46(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
+      '@langchain/langgraph': 1.3.0(@langchain/core@1.1.46(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)(zod@3.25.76)
+      '@langchain/langgraph-checkpoint': 1.0.1(@langchain/core@1.1.46(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))
       langsmith: 0.7.1(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
-      zod: 4.4.3
+      zod: 3.25.76
     transitivePeerDependencies:
       - '@opentelemetry/api'
       - '@opentelemetry/exporter-trace-otlp-proto'
@@ -8752,11 +8866,11 @@ snapshots:
       - ws
       - zod-to-json-schema
 
-  langchain@1.4.1(@langchain/core@1.1.47(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0):
+  langchain@1.4.2(@langchain/core@1.1.48(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0):
     dependencies:
-      '@langchain/core': 1.1.47(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
-      '@langchain/langgraph': 1.3.0(@langchain/core@1.1.47(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)(zod@4.4.3)
-      '@langchain/langgraph-checkpoint': 1.0.2(@langchain/core@1.1.47(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))
+      '@langchain/core': 1.1.48(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
+      '@langchain/langgraph': 1.3.2(@langchain/core@1.1.48(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod@4.4.3)
+      '@langchain/langgraph-checkpoint': 1.0.2(@langchain/core@1.1.48(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))
       langsmith: 0.7.1(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
       zod: 4.4.3
     transitivePeerDependencies:
@@ -9744,7 +9858,7 @@ snapshots:
 
   rimraf@2.6.3:
     dependencies:
-      glob: 7.2.0
+      glob: 7.2.3
 
   roarr@2.15.4:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,10 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  '@langchain/core': ^1.1.46
+  '@langchain/langgraph': ^1.3.0
+
 importers:
 
   .:
@@ -31,19 +35,16 @@ importers:
         version: 1.0.64
       '@langchain/anthropic':
         specifier: ^1.3.29
-        version: 1.3.29(@langchain/core@1.1.48(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))
+        version: 1.3.29(@langchain/core@1.1.46(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))
       '@langchain/core':
-        specifier: ^1.1.47
-        version: 1.1.48(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
-      '@langchain/google-genai':
-        specifier: ^2.1.31
-        version: 2.1.31(@langchain/core@1.1.48(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))
+        specifier: ^1.1.46
+        version: 1.1.46(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
       '@langchain/langgraph':
         specifier: ^1.3.0
-        version: 1.3.0(@langchain/core@1.1.48(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)(zod@4.4.3)
+        version: 1.3.0(@langchain/core@1.1.46(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)(zod@4.4.3)
       '@langchain/openai':
         specifier: ^1.4.5
-        version: 1.4.5(@langchain/core@1.1.48(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(ws@8.20.0)
+        version: 1.4.5(@langchain/core@1.1.46(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(ws@8.20.0)
       '@libsql/client':
         specifier: ^0.14.0
         version: 0.14.0
@@ -122,12 +123,6 @@ importers:
       katex:
         specifier: ^0.16.45
         version: 0.16.45
-      langchain:
-        specifier: ^1.4.1
-        version: 1.4.2(@langchain/core@1.1.48(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)
-      lru-cache:
-        specifier: ^11.5.0
-        version: 11.5.0
       lucide-react:
         specifier: ^0.574.0
         version: 0.574.0(react@19.2.5)
@@ -137,9 +132,6 @@ importers:
       nanoid:
         specifier: ^5.1.9
         version: 5.1.9
-      p-limit:
-        specifier: ^3.1.0
-        version: 3.1.0
       pdf-lib:
         specifier: ^1.17.1
         version: 1.17.1
@@ -228,9 +220,6 @@ importers:
       eslint-plugin-react-refresh:
         specifier: ^0.4.24
         version: 0.4.26(eslint@9.39.4(jiti@2.6.1))
-      happy-dom:
-        specifier: ^20.9.0
-        version: 20.9.0
       postcss:
         specifier: ^8.4.49
         version: 8.5.10
@@ -254,7 +243,7 @@ importers:
         version: 7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
       vitest:
         specifier: ^4.1.6
-        version: 4.1.6(@types/node@22.19.17)(happy-dom@20.9.0)(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.7(@types/node@22.19.17)(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
 
 packages:
 
@@ -986,10 +975,6 @@ packages:
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
 
-  '@google/generative-ai@0.24.1':
-    resolution: {integrity: sha512-MqO+MLfM6kjxcKoy0p1wRzG3b4ZZXtPI+z2IE26UogS2Cm/XHO+7gGRBh6gcJsOiIVoH93UwKvW4HdgiOZCy9Q==}
-    engines: {node: '>=18.0.0'}
-
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
     engines: {node: '>=18.18.0'}
@@ -1047,16 +1032,6 @@ packages:
     resolution: {integrity: sha512-i8rDC83BpItxChCw4Lf+6tAr+k+OUcbirc5ZkrhI9ywYWmvxegUljLGOGYvtJNTbEAIFkhYIODPE5QRqyjF6sA==}
     engines: {node: '>=20'}
 
-  '@langchain/core@1.1.48':
-    resolution: {integrity: sha512-fQU6Guyb1pwc2fEplmA8FPbKfOMAofjnyJzExevro0FxEiuGHE18Ov/ZHmT9trWCDTZRI9eW1VIc6aChxV8pAQ==}
-    engines: {node: '>=20'}
-
-  '@langchain/google-genai@2.1.31':
-    resolution: {integrity: sha512-lHIJGtZab0jqoufKRPXyHHg1nLXrE74LXd0ftgibWEACc1SpSLu6XwtA23+dX4l7Q/YeSgb9n40YJx5k00/fqw==}
-    engines: {node: '>=20'}
-    peerDependencies:
-      '@langchain/core': ^1.1.47
-
   '@langchain/langgraph-checkpoint@1.0.1':
     resolution: {integrity: sha512-HM0cJLRpIsSlWBQ/xuDC67l52SqZ62Bh2Y61DX+Xorqwoh5e1KxYvfCD7GnSTbWWhjBOutvnR0vPhu4orFkZfw==}
     engines: {node: '>=18'}
@@ -1086,37 +1061,8 @@ packages:
       vue:
         optional: true
 
-  '@langchain/langgraph-sdk@1.9.5':
-    resolution: {integrity: sha512-NMcz1rEKuVz07ZqcSzNJZCZR9FppRNh+/YWjCKtwZ7a/WNytDEAh26qXTtmDQZ7+J+1nEXhHym1wZDrOxA99wg==}
-    peerDependencies:
-      '@langchain/core': ^1.1.44
-      react: ^18 || ^19
-      react-dom: ^18 || ^19
-      svelte: ^4.0.0 || ^5.0.0
-      vue: ^3.0.0
-    peerDependenciesMeta:
-      react:
-        optional: true
-      react-dom:
-        optional: true
-      svelte:
-        optional: true
-      vue:
-        optional: true
-
   '@langchain/langgraph@1.3.0':
     resolution: {integrity: sha512-QvhTjiyqFPz81A+y6LHs223w6DTjv5+882DT4mup72bd72rRhNjTYo5fhes5um0swnKArvY/arc7KeFInfHHWw==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      '@langchain/core': ^1.1.44
-      zod: ^3.25.32 || ^4.2.0
-      zod-to-json-schema: ^3.x
-    peerDependenciesMeta:
-      zod-to-json-schema:
-        optional: true
-
-  '@langchain/langgraph@1.3.2':
-    resolution: {integrity: sha512-SL7Ktsr681R7da+1b2MVOWEbaCoFJOXEJPTGOjg4JIG4C7quWbTYC8DzxhcCxte6D/8cGp0rYDBnbKLXEpNqlA==}
     engines: {node: '>=18'}
     peerDependencies:
       '@langchain/core': ^1.1.44
@@ -2100,9 +2046,6 @@ packages:
   '@types/verror@1.10.11':
     resolution: {integrity: sha512-RlDm9K7+o5stv0Co8i8ZRGxDbrTxhJtgjqjFyVh/tXQyl/rYtTKlnTvZ88oSTeYREWurwx20Js4kTuKCsFkUtg==}
 
-  '@types/whatwg-mimetype@3.0.2':
-    resolution: {integrity: sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==}
-
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
@@ -2178,11 +2121,11 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
 
-  '@vitest/expect@4.1.6':
-    resolution: {integrity: sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg==}
+  '@vitest/expect@4.1.7':
+    resolution: {integrity: sha512-1R+tw0ortHEbZDGMymm+pN7/AFQ/RkFFdtd7EN+VBpynKmLbP8A3rpEXdshBJ7+8hQ9zBJh/i1s0yKNtxAnU7w==}
 
-  '@vitest/mocker@4.1.6':
-    resolution: {integrity: sha512-MCFc63czMjEInOlcY2cpQCvCN+KgbAn+60xu9cMgP4sKaLC5JNAKw7JH8QdAnoAC88hW1IiSNZ+GgVXlN1UcMQ==}
+  '@vitest/mocker@4.1.7':
+    resolution: {integrity: sha512-vY7nuamKgfvpA1Koa3oYIw/k7D6kZnpGyNMZW8loow2bsBYla1TFdqTaXncWdRn4pgwNs+90RhnXhJScDwQeJA==}
     peerDependencies:
       msw: ^2.4.9
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -2192,20 +2135,20 @@ packages:
       vite:
         optional: true
 
-  '@vitest/pretty-format@4.1.6':
-    resolution: {integrity: sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw==}
+  '@vitest/pretty-format@4.1.7':
+    resolution: {integrity: sha512-umgCarTOYQWIaDMvGDRZij+6b9oVeLIyJzfN+AS88e0ZOU3QTgNNSTtjQOpcvWr3np1N0j4WgZj+sb3oYBDscw==}
 
-  '@vitest/runner@4.1.6':
-    resolution: {integrity: sha512-nOPCmn2+yD0ZNmKdsXGv/UxMMWbMuKeD6GyYncNwdkYDxpQvrPSKYj2rWuDjC2Y4b6w6hjip5dBKFzEUuZe3vA==}
+  '@vitest/runner@4.1.7':
+    resolution: {integrity: sha512-BapjmAQ2aI78WdMEfeUWivnfVzB+VPGwWRQcJE0OUq7qEeEcBsCSf+0T5iREBNE5nBb4wA5Ya0W6IA+sghdEFw==}
 
-  '@vitest/snapshot@4.1.6':
-    resolution: {integrity: sha512-YhsdE6xAVfTDmzjxL2ZDUvjj+ZsgyOKe+TdQzqkD72wIOmHka8NuGQ6NpTNZv9D2Z63fbwWKJPeVpEw4EQgYxw==}
+  '@vitest/snapshot@4.1.7':
+    resolution: {integrity: sha512-ZacLzja+TmJeZ1h14xW2FB/WpeimUD3haBXQPyJqxvo8jQTmfeA8zv58mtjN2C7EHXZDYVcVYdYmAxjkWVvKCw==}
 
-  '@vitest/spy@4.1.6':
-    resolution: {integrity: sha512-JFKxMx6udhwKh/Ldo270e17QX710vgunMkuPAvXjHSvC6oqLWAHhVhjg/I71q0u0CBSErIODV1Kjv0FQNSWjdg==}
+  '@vitest/spy@4.1.7':
+    resolution: {integrity: sha512-kbkI5LMWakyuTIvs6fUJ5qdIVb1XVKsYJAT4OJ938cHMROYMSfmoQdZy0aaAnjbbc8F61vkoTqz/Az+/HiIu5Q==}
 
-  '@vitest/utils@4.1.6':
-    resolution: {integrity: sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==}
+  '@vitest/utils@4.1.7':
+    resolution: {integrity: sha512-T532WBu791cBxJlCl6SO+J14l81DQx6uQHm1bQbmCDY7nqlEIgkza/UFnSBNaUtSf41unldDFjdOBYEQC4b5Hw==}
 
   '@xmldom/xmldom@0.8.12':
     resolution: {integrity: sha512-9k/gHF6n/pAi/9tqr3m3aqkuiNosYTurLLUtc7xQ9sxB/wm7WPygCv8GYa6mS0fLJEHhqMC1ATYhz++U/lRHqg==}
@@ -3302,10 +3245,6 @@ packages:
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
-  happy-dom@20.9.0:
-    resolution: {integrity: sha512-GZZ9mKe8r646NUAf/zemnGbjYh4Bt8/MqASJY+pSm5ZDtc3YQox+4gsLI7yi1hba6o+eCsGxpHn5+iEVn31/FQ==}
-    engines: {node: '>=20.0.0'}
-
   has-bigints@1.1.0:
     resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
     engines: {node: '>= 0.4'}
@@ -3658,12 +3597,6 @@ packages:
     peerDependencies:
       '@langchain/core': ^1.1.44
 
-  langchain@1.4.2:
-    resolution: {integrity: sha512-SLGipy0r4nqQD0aiUOBYLMeGFfB/QiYnMndfZ8sGN89vXDCIXbYqcE7G/4QDDX3nZsM7/emQpoScmlxEX6sDnQ==}
-    engines: {node: '>=20'}
-    peerDependencies:
-      '@langchain/core': ^1.1.48
-
   langsmith@0.7.1:
     resolution: {integrity: sha512-Wjk90UjNoY5cBHMlNAC/eZx5clI8jnjBOBW8uJu8+MWBtx0QesNjsUiLtjI+I3UnrpxFFpDqGXcnhBjH654Mqg==}
     peerDependencies:
@@ -3810,10 +3743,6 @@ packages:
 
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
-
-  lru-cache@11.5.0:
-    resolution: {integrity: sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA==}
-    engines: {node: 20 || >=22}
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
@@ -5033,20 +4962,20 @@ packages:
       yaml:
         optional: true
 
-  vitest@4.1.6:
-    resolution: {integrity: sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==}
+  vitest@4.1.7:
+    resolution: {integrity: sha512-flYyaFd2CgoCoU+0UKt3pxksgC+S02iTDN0n3LtqaMeXsI9SBcdNujc2k0DeFLzUn/0k538yNjOSdwgCqcrwJA==}
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@opentelemetry/api': ^1.9.0
       '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
-      '@vitest/browser-playwright': 4.1.6
-      '@vitest/browser-preview': 4.1.6
-      '@vitest/browser-webdriverio': 4.1.6
-      '@vitest/coverage-istanbul': 4.1.6
-      '@vitest/coverage-v8': 4.1.6
-      '@vitest/ui': 4.1.6
+      '@vitest/browser-playwright': 4.1.7
+      '@vitest/browser-preview': 4.1.7
+      '@vitest/browser-webdriverio': 4.1.7
+      '@vitest/coverage-istanbul': 4.1.7
+      '@vitest/coverage-v8': 4.1.7
+      '@vitest/ui': 4.1.7
       happy-dom: '*'
       jsdom: '*'
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -5085,10 +5014,6 @@ packages:
     resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
     engines: {node: '>=18'}
     deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
-
-  whatwg-mimetype@3.0.0:
-    resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
-    engines: {node: '>=12'}
 
   whatwg-mimetype@4.0.0:
     resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
@@ -5841,8 +5766,6 @@ snapshots:
 
   '@floating-ui/utils@0.2.11': {}
 
-  '@google/generative-ai@0.24.1': {}
-
   '@humanfs/core@0.19.2':
     dependencies:
       '@humanfs/types': 0.15.0
@@ -5893,10 +5816,10 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@langchain/anthropic@1.3.29(@langchain/core@1.1.48(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))':
+  '@langchain/anthropic@1.3.29(@langchain/core@1.1.46(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))':
     dependencies:
       '@anthropic-ai/sdk': 0.91.1(zod@3.25.76)
-      '@langchain/core': 1.1.48(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
+      '@langchain/core': 1.1.46(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
       zod: 3.25.76
 
   '@langchain/core@1.1.46(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)':
@@ -5915,27 +5838,6 @@ snapshots:
       - openai
       - ws
 
-  '@langchain/core@1.1.48(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)':
-    dependencies:
-      '@cfworker/json-schema': 4.1.1
-      '@standard-schema/spec': 1.1.0
-      js-tiktoken: 1.0.21
-      langsmith: 0.7.1(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
-      mustache: 4.2.0
-      p-queue: 6.6.2
-      zod: 4.4.3
-    transitivePeerDependencies:
-      - '@opentelemetry/api'
-      - '@opentelemetry/exporter-trace-otlp-proto'
-      - '@opentelemetry/sdk-trace-base'
-      - openai
-      - ws
-
-  '@langchain/google-genai@2.1.31(@langchain/core@1.1.48(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))':
-    dependencies:
-      '@google/generative-ai': 0.24.1
-      '@langchain/core': 1.1.48(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
-
   '@langchain/langgraph-checkpoint@1.0.1(@langchain/core@1.1.46(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))':
     dependencies:
       '@langchain/core': 1.1.46(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
@@ -5944,11 +5846,6 @@ snapshots:
   '@langchain/langgraph-checkpoint@1.0.2(@langchain/core@1.1.46(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))':
     dependencies:
       '@langchain/core': 1.1.46(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
-      uuid: 10.0.0
-
-  '@langchain/langgraph-checkpoint@1.0.2(@langchain/core@1.1.48(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))':
-    dependencies:
-      '@langchain/core': 1.1.48(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
       uuid: 10.0.0
 
   '@langchain/langgraph-sdk@1.9.2(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)':
@@ -5968,18 +5865,6 @@ snapshots:
       - '@opentelemetry/sdk-trace-base'
       - openai
       - ws
-
-  '@langchain/langgraph-sdk@1.9.5(@langchain/core@1.1.48(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
-    dependencies:
-      '@langchain/core': 1.1.48(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
-      '@langchain/protocol': 0.0.15
-      '@types/json-schema': 7.0.15
-      p-queue: 9.1.2
-      p-retry: 7.1.1
-      uuid: 13.0.0
-    optionalDependencies:
-      react: 19.2.5
-      react-dom: 19.2.5(react@19.2.5)
 
   '@langchain/langgraph@1.3.0(@langchain/core@1.1.46(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)(zod@3.25.76)':
     dependencies:
@@ -6021,44 +5906,9 @@ snapshots:
       - vue
       - ws
 
-  '@langchain/langgraph@1.3.0(@langchain/core@1.1.48(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)(zod@4.4.3)':
+  '@langchain/openai@1.4.5(@langchain/core@1.1.46(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(ws@8.20.0)':
     dependencies:
-      '@langchain/core': 1.1.48(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
-      '@langchain/langgraph-checkpoint': 1.0.2(@langchain/core@1.1.48(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))
-      '@langchain/langgraph-sdk': 1.9.2(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)
-      '@langchain/protocol': 0.0.15
-      '@standard-schema/spec': 1.1.0
-      uuid: 10.0.0
-      zod: 4.4.3
-    transitivePeerDependencies:
-      - '@opentelemetry/api'
-      - '@opentelemetry/exporter-trace-otlp-proto'
-      - '@opentelemetry/sdk-trace-base'
-      - openai
-      - react
-      - react-dom
-      - svelte
-      - vue
-      - ws
-
-  '@langchain/langgraph@1.3.2(@langchain/core@1.1.48(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod@4.4.3)':
-    dependencies:
-      '@langchain/core': 1.1.48(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
-      '@langchain/langgraph-checkpoint': 1.0.2(@langchain/core@1.1.48(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))
-      '@langchain/langgraph-sdk': 1.9.5(@langchain/core@1.1.48(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@langchain/protocol': 0.0.15
-      '@standard-schema/spec': 1.1.0
-      uuid: 10.0.0
-      zod: 4.4.3
-    transitivePeerDependencies:
-      - react
-      - react-dom
-      - svelte
-      - vue
-
-  '@langchain/openai@1.4.5(@langchain/core@1.1.48(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(ws@8.20.0)':
-    dependencies:
-      '@langchain/core': 1.1.48(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
+      '@langchain/core': 1.1.46(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
       js-tiktoken: 1.0.21
       openai: 6.34.0(ws@8.20.0)(zod@3.25.76)
       zod: 3.25.76
@@ -6960,8 +6810,6 @@ snapshots:
   '@types/verror@1.10.11':
     optional: true
 
-  '@types/whatwg-mimetype@3.0.2': {}
-
   '@types/ws@8.18.1':
     dependencies:
       '@types/node': 22.19.17
@@ -7076,44 +6924,44 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/expect@4.1.6':
+  '@vitest/expect@4.1.7':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
-      '@vitest/spy': 4.1.6
-      '@vitest/utils': 4.1.6
+      '@vitest/spy': 4.1.7
+      '@vitest/utils': 4.1.7
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.6(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))':
+  '@vitest/mocker@4.1.7(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
-      '@vitest/spy': 4.1.6
+      '@vitest/spy': 4.1.7
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       vite: 7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
 
-  '@vitest/pretty-format@4.1.6':
+  '@vitest/pretty-format@4.1.7':
     dependencies:
       tinyrainbow: 3.1.0
 
-  '@vitest/runner@4.1.6':
+  '@vitest/runner@4.1.7':
     dependencies:
-      '@vitest/utils': 4.1.6
+      '@vitest/utils': 4.1.7
       pathe: 2.0.3
 
-  '@vitest/snapshot@4.1.6':
+  '@vitest/snapshot@4.1.7':
     dependencies:
-      '@vitest/pretty-format': 4.1.6
-      '@vitest/utils': 4.1.6
+      '@vitest/pretty-format': 4.1.7
+      '@vitest/utils': 4.1.7
       magic-string: 0.30.21
       pathe: 2.0.3
 
-  '@vitest/spy@4.1.6': {}
+  '@vitest/spy@4.1.7': {}
 
-  '@vitest/utils@4.1.6':
+  '@vitest/utils@4.1.7':
     dependencies:
-      '@vitest/pretty-format': 4.1.6
+      '@vitest/pretty-format': 4.1.7
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
@@ -8467,18 +8315,6 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
-  happy-dom@20.9.0:
-    dependencies:
-      '@types/node': 22.19.17
-      '@types/whatwg-mimetype': 3.0.2
-      '@types/ws': 8.18.1
-      entities: 7.0.1
-      whatwg-mimetype: 3.0.0
-      ws: 8.20.0
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-
   has-bigints@1.1.0: {}
 
   has-flag@4.0.0: {}
@@ -8866,25 +8702,6 @@ snapshots:
       - ws
       - zod-to-json-schema
 
-  langchain@1.4.2(@langchain/core@1.1.48(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0):
-    dependencies:
-      '@langchain/core': 1.1.48(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
-      '@langchain/langgraph': 1.3.2(@langchain/core@1.1.48(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod@4.4.3)
-      '@langchain/langgraph-checkpoint': 1.0.2(@langchain/core@1.1.48(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0))
-      langsmith: 0.7.1(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0)
-      zod: 4.4.3
-    transitivePeerDependencies:
-      - '@opentelemetry/api'
-      - '@opentelemetry/exporter-trace-otlp-proto'
-      - '@opentelemetry/sdk-trace-base'
-      - openai
-      - react
-      - react-dom
-      - svelte
-      - vue
-      - ws
-      - zod-to-json-schema
-
   langsmith@0.7.1(openai@6.34.0(ws@8.20.0)(zod@4.4.3))(ws@8.20.0):
     dependencies:
       p-queue: 6.6.2
@@ -8997,8 +8814,6 @@ snapshots:
   lowercase-keys@2.0.0: {}
 
   lru-cache@10.4.3: {}
-
-  lru-cache@11.5.0: {}
 
   lru-cache@5.1.1:
     dependencies:
@@ -10473,15 +10288,15 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.8.3
 
-  vitest@4.1.6(@types/node@22.19.17)(happy-dom@20.9.0)(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)):
+  vitest@4.1.7(@types/node@22.19.17)(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
-      '@vitest/expect': 4.1.6
-      '@vitest/mocker': 4.1.6(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
-      '@vitest/pretty-format': 4.1.6
-      '@vitest/runner': 4.1.6
-      '@vitest/snapshot': 4.1.6
-      '@vitest/spy': 4.1.6
-      '@vitest/utils': 4.1.6
+      '@vitest/expect': 4.1.7
+      '@vitest/mocker': 4.1.7(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/pretty-format': 4.1.7
+      '@vitest/runner': 4.1.7
+      '@vitest/snapshot': 4.1.7
+      '@vitest/spy': 4.1.7
+      '@vitest/utils': 4.1.7
       es-module-lexer: 2.1.0
       expect-type: 1.3.0
       magic-string: 0.30.21
@@ -10497,7 +10312,6 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.19.17
-      happy-dom: 20.9.0
     transitivePeerDependencies:
       - msw
 
@@ -10510,8 +10324,6 @@ snapshots:
   whatwg-encoding@3.1.1:
     dependencies:
       iconv-lite: 0.6.3
-
-  whatwg-mimetype@3.0.0: {}
 
   whatwg-mimetype@4.0.0: {}
 

--- a/src/main/ipc/io/export-handlers.ts
+++ b/src/main/ipc/io/export-handlers.ts
@@ -52,6 +52,21 @@ const parseFontEmbedMode = (payload: unknown): 'auto' | 'always' | 'never' => {
 const sanitizeExportBaseName = (value: string, fallback: string): string =>
   value.replace(/[\\/:*?"<>|]/g, '_').slice(0, 120) || fallback
 
+const readTransitionTypeFromIndex = (projectDir: string): string | undefined => {
+  const indexPath = path.join(projectDir, 'index.html')
+  try {
+    const html = fs.readFileSync(indexPath, 'utf-8')
+    const match = html.match(
+      /<script\b[^>]*id=["']ppt-index-transition-config["'][^>]*>([\s\S]*?)<\/script>/i
+    )
+    if (!match) return undefined
+    const config = JSON.parse(match[1].trim())
+    return config?.type && config.type !== 'none' ? String(config.type) : undefined
+  } catch {
+    return undefined
+  }
+}
+
 const isSameOrChildPath = async (candidatePath: string, parentPath: string): Promise<boolean> => {
   const resolveRealPath = async (value: string): Promise<string> =>
     fs.promises.realpath(value).catch(() => path.resolve(value))
@@ -321,6 +336,29 @@ export function registerExportHandlers(ctx: IpcContext): void {
         if (pagesWithoutText > 0) {
           warnings.push(`${pages.length} 页中有 ${pagesWithoutText} 页未提取到可编辑文本。`)
         }
+      }
+
+      // Apply slide transition from index.html config
+      const transitionType = readTransitionTypeFromIndex(projectDir)
+      if (transitionType) {
+        for (const slide of slides) {
+          if (!slide.transitionType) {
+            slide.transitionType = transitionType
+          }
+        }
+        log.info('[export:pptx] applied transition from index', { sessionId, transitionType })
+      }
+
+      // Log animation trace stats
+      const slidesWithAnim = slides.filter((s) => (s.animationTraces?.length ?? 0) > 0)
+      if (slidesWithAnim.length > 0) {
+        log.info('[export:pptx] animation traces collected', {
+          sessionId,
+          slidesWithAnim: slidesWithAnim.length,
+          totalTraces: slidesWithAnim.reduce((n, s) => n + (s.animationTraces?.length ?? 0), 0)
+        })
+      } else {
+        log.info('[export:pptx] no animation traces found in any slide', { sessionId })
       }
 
       // Collect embedded fonts (editable mode only). The user-facing behavior is

--- a/src/main/utils/anim-smil-writer.ts
+++ b/src/main/utils/anim-smil-writer.ts
@@ -111,13 +111,14 @@ export function buildSlideTiming(timing: SmilSlideTiming, startNodeId = 1000): s
       }
 
       const filterXml = preset.filter
-        ? `\n                    <p:animEffect transition="in" filter="${preset.filter}">
-                      <p:cTn id="${nextId()}" dur="${durMs}"/>
-                      <p:target><p:spTgt spid="${anim.spid}"/></p:target>
-                    </p:animEffect>`
+        ? `\n                      <p:animEffect transition="in" filter="${preset.filter}">
+                        <p:cTn id="${nextId()}" dur="${durMs}"/>
+                        <p:target><p:spTgt spid="${anim.spid}"/></p:target>
+                      </p:animEffect>`
         : ''
 
       const nodeType = `nodeType="${preset.filter ? 'withEffect' : 'afterEffect'}"`
+      const setId = nextId()
 
       return `<p:par>
                   <p:cTn id="${shapeParId}" fill="hold">
@@ -127,6 +128,13 @@ export function buildSlideTiming(timing: SmilSlideTiming, startNodeId = 1000): s
                         <p:cTn id="${effectId}" dur="${durMs}" fill="hold"/>
                         <p:target><p:spTgt spid="${anim.spid}"/></p:target>
                       </p:animEffect>${filterXml}
+                      <p:set>
+                        <p:cTn id="${setId}" dur="1" fill="hold">
+                          <p:stCondLst><p:cond delay="0"/></p:stCondLst>
+                        </p:cTn>
+                        <p:target><p:spTgt spid="${anim.spid}"/></p:target>
+                        <p:to><p:strVal val="visible"/></p:to>
+                      </p:set>
                     </p:childTnLst>
                   </p:cTn>
                 </p:par>`

--- a/src/main/utils/anim-smil-writer.ts
+++ b/src/main/utils/anim-smil-writer.ts
@@ -186,6 +186,9 @@ export function mapTransitionToPptx(
     'slide-up': 'push',
     push: 'push',
     wipe: 'wipe',
+    cover: 'cover',
+    uncover: 'uncover',
+    dissolve: 'dissolve',
     zoom: 'dissolve'
   }
   if (type === 'none') return 'none'

--- a/src/main/utils/anim-smil-writer.ts
+++ b/src/main/utils/anim-smil-writer.ts
@@ -46,7 +46,7 @@ const SMIL_PRESET: Record<
   SmilAnimType,
   { presetID: number; presetClass: string; presetSubtype?: number; filter?: string }
 > = {
-  fade:       { presetID: 10, presetClass: 'entr', filter: 'fade' },
+  fade:       { presetID: 10, presetClass: 'entr' },
   'fade-up':  { presetID: 7,  presetClass: 'entr', presetSubtype: 8, filter: 'fade' },
   'fade-down':{ presetID: 7,  presetClass: 'entr', presetSubtype: 1, filter: 'fade' },
   'fade-left':{ presetID: 7,  presetClass: 'entr', presetSubtype: 2, filter: 'fade' },
@@ -54,11 +54,6 @@ const SMIL_PRESET: Record<
   'scale-in': { presetID: 31, presetClass: 'entr' },
   'slide-up': { presetID: 7,  presetClass: 'entr', presetSubtype: 8 },
   'slide-left':{ presetID: 7,  presetClass: 'entr', presetSubtype: 2 }
-}
-
-const NS = {
-  p: 'http://schemas.openxmlformats.org/presentationml/2006/main',
-  p14: 'http://schemas.microsoft.com/office/powerpoint/2010/main'
 }
 
 let _nextNodeId = 1000
@@ -84,11 +79,6 @@ function buildAnimEffectAttrs(anim: SmilElementAnim): string {
   return attrs
 }
 
-function buildFilterElement(filter?: string): string {
-  if (!filter) return ''
-  return `\n                  <p:animEffect transition="in" filter="${filter}"/>`
-}
-
 /**
  * Build a <p:timing> block for a slide from a list of element animations.
  * Each element gets its own <p:animEffect> inside a <p:seq> container.
@@ -101,7 +91,7 @@ export function buildSlideTiming(timing: SmilSlideTiming): string {
   if (!timing.elements || timing.elements.length === 0) return ''
 
   const nodeId = nextNodeId()
-  const children = timing.elements
+  const children = [...timing.elements]
     .sort((a, b) => a.order - b.order)
     .map((anim) => {
       const preset = SMIL_PRESET[anim.type]
@@ -159,6 +149,8 @@ ${children}
 
 /**
  * Build a <p:transition> element for slide-level transitions.
+ * PPTX spec: child element defines type (e.g. <p:fade/>),
+ * spd is speed (slow/med/fast), advClick controls advance-on-click.
  */
 export function buildSlideTransition(
   type: 'fade' | 'push' | 'wipe' | 'cover' | 'uncover' | 'dissolve' | 'none',
@@ -166,7 +158,7 @@ export function buildSlideTransition(
 ): string {
   if (type === 'none') return ''
 
-  const transitionMap: Record<string, string> = {
+  const childMap: Record<string, string> = {
     fade: 'fade',
     push: 'push',
     wipe: 'wipe',
@@ -175,10 +167,11 @@ export function buildSlideTransition(
     dissolve: 'dissolve'
   }
 
-  const spd = transitionMap[type] || 'fade'
-  const dur = Math.round(Math.max(100, Math.min(5000, durationMs || 400)))
+  const dur = Math.max(100, Math.min(5000, durationMs || 400))
+  const spd = dur <= 300 ? 'fast' : dur <= 700 ? 'med' : 'slow'
+  const child = childMap[type] || 'fade'
 
-  return `<p:transition spd="${spd}" dur="${dur}" advClick="1"/>`
+  return `<p:transition spd="${spd}" advClick="1"><p:${child}/></p:transition>`
 }
 
 /**

--- a/src/main/utils/anim-smil-writer.ts
+++ b/src/main/utils/anim-smil-writer.ts
@@ -167,11 +167,11 @@ export function buildSlideTransition(
     dissolve: 'dissolve'
   }
 
-  const dur = Math.max(100, Math.min(5000, durationMs || 400))
+  const dur = Math.max(100, Math.min(5000, durationMs ?? 400))
   const spd = dur <= 300 ? 'fast' : dur <= 700 ? 'med' : 'slow'
   const child = childMap[type] || 'fade'
 
-  return `<p:transition spd="${spd}" advClick="1"><p:${child}/></p:transition>`
+  return `<p:transition spd="${spd}" dur="${dur}" advClick="1"><p:${child}/></p:transition>`
 }
 
 /**

--- a/src/main/utils/anim-smil-writer.ts
+++ b/src/main/utils/anim-smil-writer.ts
@@ -2,20 +2,45 @@
  * Maps declarative data-anim animation configs to PPTX SMIL XML
  * for native PowerPoint animation round-trip.
  *
- * PPTX SMIL reference:
- *   presetID / presetClass / presetSubtype on <p:animEffect>
+ * PowerPoint SMIL structure (simplified):
+ *   <p:timing>
+ *     <p:tnLst>
+ *       <p:par>                          <!-- root par -->
+ *         <p:cTn id dur="indefinite" nodeType="tmRoot">
+ *           <p:childTnLst>
+ *             <p:seq concurrent="1" nextAc="seek">
+ *               <p:cTn id dur="indefinite" nodeType="mainSeq">
+ *                 <p:childTnLst>
+ *                   <p:par>              <!-- click group (afterPrevious) -->
+ *                     <p:cTn id fill="hold">
+ *                       <p:stCondLst><p:cond delay="0"/></p:stCondLst>
+ *                       <p:childTnLst>
+ *                         <p:par>        <!-- per-shape par -->
+ *                           ...
+ *                         </p:par>
+ *                       </p:childTnLst>
+ *                     </p:cTn>
+ *                   </p:par>
+ *                 </p:childTnLst>
+ *               </p:cTn>
+ *               <p:prevCondLst>...</p:prevCondLst>
+ *               <p:nextCondLst>...</p:nextCondLst>
+ *             </p:seq>
+ *           </p:childTnLst>
+ *         </p:cTn>
+ *       </p:par>
+ *     </p:tnLst>
+ *   </p:timing>
  *
- *   fade      (10)  → entrance fade
- *   fade-up   (7/8) → entrance fly from bottom + fade filter
- *   fade-down (7/1) → entrance fly from top + fade filter
- *   fade-left (7/2) → entrance fly from left + fade filter
- *   fade-right(7/3) → entrance fly from right + fade filter
- *   scale-in  (31)  → entrance zoom
- *   slide-up  (7/8) → entrance fly from bottom
- *   slide-left(7/2) → entrance fly from left
- *
- * Complex timelines, spring easing, and custom PPT.animate() scripts
- * are NOT mapped — they fall back to static screenshot export.
+ * Animation types supported:
+ *   fade (10)      → entrance fade
+ *   fade-up (7/8)  → entrance fly from bottom
+ *   fade-down (7/1)→ entrance fly from top
+ *   fade-left (7/2)→ entrance fly from left
+ *   fade-right(7/3)→ entrance fly from right
+ *   scale-in (31)  → entrance zoom
+ *   slide-up (7/8) → entrance fly from bottom
+ *   slide-left(7/2)→ entrance fly from left
  */
 
 export type SmilAnimType =
@@ -29,53 +54,31 @@ export type SmilAnimType =
   | 'slide-left'
 
 export interface SmilElementAnim {
-  spid: number // shape ID in the slide XML
+  spid: number
   type: SmilAnimType
-  duration: number // ms
-  delay: number // ms
-  order: number // sequence index within slide
+  duration: number
+  delay: number
+  order: number
 }
 
 export interface SmilSlideTiming {
   elements: SmilElementAnim[]
 }
 
-// PPTX presetID values: 10=fade, 7=fly, 31=zoom
-// presetSubtype for fly (7): 1=top, 2=left, 3=right, 8=bottom
 const SMIL_PRESET: Record<
   SmilAnimType,
   { presetID: number; presetClass: string; presetSubtype?: number; filter?: string }
 > = {
-  fade:       { presetID: 10, presetClass: 'entr' },
-  'fade-up':  { presetID: 7,  presetClass: 'entr', presetSubtype: 8, filter: 'fade' },
-  'fade-down':{ presetID: 7,  presetClass: 'entr', presetSubtype: 1, filter: 'fade' },
-  'fade-left':{ presetID: 7,  presetClass: 'entr', presetSubtype: 2, filter: 'fade' },
+  fade:        { presetID: 10, presetClass: 'entr' },
+  'fade-up':   { presetID: 7,  presetClass: 'entr', presetSubtype: 8, filter: 'fade' },
+  'fade-down': { presetID: 7,  presetClass: 'entr', presetSubtype: 1, filter: 'fade' },
+  'fade-left': { presetID: 7,  presetClass: 'entr', presetSubtype: 2, filter: 'fade' },
   'fade-right':{ presetID: 7,  presetClass: 'entr', presetSubtype: 3, filter: 'fade' },
-  'scale-in': { presetID: 31, presetClass: 'entr' },
-  'slide-up': { presetID: 7,  presetClass: 'entr', presetSubtype: 8 },
+  'scale-in':  { presetID: 31, presetClass: 'entr' },
+  'slide-up':  { presetID: 7,  presetClass: 'entr', presetSubtype: 8 },
   'slide-left':{ presetID: 7,  presetClass: 'entr', presetSubtype: 2 }
 }
 
-function buildAnimEffectAttrs(anim: SmilElementAnim): string {
-  const preset = SMIL_PRESET[anim.type]
-  if (!preset) return ''
-
-  let attrs = `presetID="${preset.presetID}" presetClass="${preset.presetClass}"`
-  if (preset.presetSubtype !== undefined) {
-    attrs += ` presetSubtype="${preset.presetSubtype}"`
-  }
-  attrs += ' transition="in"'
-  return attrs
-}
-
-/**
- * Build a <p:timing> block for a slide from a list of element animations.
- * Each element gets its own <p:animEffect> inside a <p:seq> container.
- *
- * For types with both motion (fly) and fade, two sibling animEffect
- * elements are generated inside a <p:childTnLst> — one for the motion
- * path, one for the fade filter.
- */
 export function buildSlideTiming(timing: SmilSlideTiming, startNodeId = 1000): string {
   if (!timing.elements || timing.elements.length === 0) return ''
 
@@ -85,44 +88,48 @@ export function buildSlideTiming(timing: SmilSlideTiming, startNodeId = 1000): s
     return nodeId
   }
 
-  const seqNodeId = nextId()
+  const rootParId = nextId()
+  const seqId = nextId()
+  const mainSeqId = nextId()
+  const clickGroupId = nextId()
+
   const children = [...timing.elements]
     .sort((a, b) => a.order - b.order)
     .map((anim) => {
       const preset = SMIL_PRESET[anim.type]
       if (!preset) return ''
 
-      const animNodeId = nextId()
       const durMs = Math.max(100, Math.min(5000, anim.duration))
       const delayMs = Math.max(0, anim.delay)
 
-      // Base effect: preset-driven entrance (fade, fly, zoom)
-      const baseAttrs = buildAnimEffectAttrs(anim)
+      const shapeParId = nextId()
+      const effectId = nextId()
 
-      // Optional filter: layered fade on top of fly motion
-      const filterChunk = preset.filter
-        ? `\n                  <p:animEffect transition="in" filter="${preset.filter}">` +
-          `\n                    <p:cTn id="${nextId()}" dur="${durMs}">` +
-          '\n                      <p:stCondLst>' +
-          `\n                        <p:cond delay="${delayMs}"/>` +
-          '\n                      </p:stCondLst>' +
-          '\n                    </p:cTn>' +
-          `\n                    <p:target>` +
-          `\n                      <p:spTgt spid="${anim.spid}"/>` +
-          '\n                    </p:target>' +
-          '\n                  </p:animEffect>'
+      let attrs = `presetID="${preset.presetID}" presetClass="${preset.presetClass}"`
+      if (preset.presetSubtype !== undefined) {
+        attrs += ` presetSubtype="${preset.presetSubtype}"`
+      }
+
+      const filterXml = preset.filter
+        ? `\n                    <p:animEffect transition="in" filter="${preset.filter}">
+                      <p:cTn id="${nextId()}" dur="${durMs}"/>
+                      <p:target><p:spTgt spid="${anim.spid}"/></p:target>
+                    </p:animEffect>`
         : ''
 
-      return `\n                <p:animEffect ${baseAttrs}>
-                  <p:cTn id="${animNodeId}" dur="${durMs}">
-                    <p:stCondLst>
-                      <p:cond delay="${delayMs}"/>
-                    </p:stCondLst>
+      const nodeType = `nodeType="${preset.filter ? 'withEffect' : 'afterEffect'}"`
+
+      return `<p:par>
+                  <p:cTn id="${shapeParId}" fill="hold">
+                    <p:stCondLst><p:cond delay="${delayMs}"/></p:stCondLst>
+                    <p:childTnLst>
+                      <p:animEffect ${attrs} transition="in" ${nodeType}>
+                        <p:cTn id="${effectId}" dur="${durMs}" fill="hold"/>
+                        <p:target><p:spTgt spid="${anim.spid}"/></p:target>
+                      </p:animEffect>${filterXml}
+                    </p:childTnLst>
                   </p:cTn>
-                  <p:target>
-                    <p:spTgt spid="${anim.spid}"/>
-                  </p:target>
-                </p:animEffect>${filterChunk}`
+                </p:par>`
     })
     .filter(Boolean)
     .join('\n')
@@ -131,22 +138,36 @@ export function buildSlideTiming(timing: SmilSlideTiming, startNodeId = 1000): s
 
   return `<p:timing>
     <p:tnLst>
-      <p:seq concurrent="0" nextAc="seek">
-        <p:cTn id="${seqNodeId}" dur="indefinite">
+      <p:par>
+        <p:cTn id="${rootParId}" dur="indefinite" restart="never" nodeType="tmRoot">
           <p:childTnLst>
+            <p:seq concurrent="1" nextAc="seek">
+              <p:cTn id="${mainSeqId}" dur="indefinite" nodeType="mainSeq">
+                <p:childTnLst>
+                  <p:par>
+                    <p:cTn id="${clickGroupId}" fill="hold">
+                      <p:stCondLst><p:cond delay="0"/></p:stCondLst>
+                      <p:childTnLst>
 ${children}
+                      </p:childTnLst>
+                    </p:cTn>
+                  </p:par>
+                </p:childTnLst>
+              </p:cTn>
+              <p:prevCondLst>
+                <p:cond evt="onPrev" delay="0"><p:tgtEl><p:sldTgt/></p:tgtEl></p:cond>
+              </p:prevCondLst>
+              <p:nextCondLst>
+                <p:cond evt="onNext" delay="0"><p:tgtEl><p:sldTgt/></p:tgtEl></p:cond>
+              </p:nextCondLst>
+            </p:seq>
           </p:childTnLst>
         </p:cTn>
-      </p:seq>
+      </p:par>
     </p:tnLst>
   </p:timing>`
 }
 
-/**
- * Build a <p:transition> element for slide-level transitions.
- * PPTX spec: child element defines type (e.g. <p:fade/>),
- * spd is speed (slow/med/fast), advClick controls advance-on-click.
- */
 export function buildSlideTransition(
   type: 'fade' | 'push' | 'wipe' | 'cover' | 'uncover' | 'dissolve' | 'none',
   durationMs?: number
@@ -166,12 +187,9 @@ export function buildSlideTransition(
   const spd = dur <= 300 ? 'fast' : dur <= 700 ? 'med' : 'slow'
   const child = childMap[type] || 'fade'
 
-  return `<p:transition spd="${spd}" dur="${dur}" advClick="1"><p:${child}/></p:transition>`
+  return `<p:transition spd="${spd}" advClick="1"><p:${child}/></p:transition>`
 }
 
-/**
- * Map our internal transition types to PPTX native transition names.
- */
 export function mapTransitionToPptx(
   type: string
 ): 'fade' | 'push' | 'wipe' | 'cover' | 'uncover' | 'dissolve' | 'none' {

--- a/src/main/utils/anim-smil-writer.ts
+++ b/src/main/utils/anim-smil-writer.ts
@@ -1,0 +1,200 @@
+/**
+ * Maps declarative data-anim animation configs to PPTX SMIL XML
+ * for native PowerPoint animation round-trip.
+ *
+ * PPTX SMIL reference:
+ *   presetID / presetClass / presetSubtype on <p:animEffect>
+ *
+ *   fade      (10)  → entrance fade
+ *   fade-up   (7/8) → entrance fly from bottom + fade filter
+ *   fade-down (7/1) → entrance fly from top + fade filter
+ *   fade-left (7/2) → entrance fly from left + fade filter
+ *   fade-right(7/3) → entrance fly from right + fade filter
+ *   scale-in  (31)  → entrance zoom
+ *   slide-up  (7/8) → entrance fly from bottom
+ *   slide-left(7/2) → entrance fly from left
+ *
+ * Complex timelines, spring easing, and custom PPT.animate() scripts
+ * are NOT mapped — they fall back to static screenshot export.
+ */
+
+export type SmilAnimType =
+  | 'fade'
+  | 'fade-up'
+  | 'fade-down'
+  | 'fade-left'
+  | 'fade-right'
+  | 'scale-in'
+  | 'slide-up'
+  | 'slide-left'
+
+export interface SmilElementAnim {
+  spid: number // shape ID in the slide XML
+  type: SmilAnimType
+  duration: number // ms
+  delay: number // ms
+  order: number // sequence index within slide
+}
+
+export interface SmilSlideTiming {
+  elements: SmilElementAnim[]
+}
+
+// PPTX presetID values: 10=fade, 7=fly, 31=zoom
+// presetSubtype for fly (7): 1=top, 2=left, 3=right, 8=bottom
+const SMIL_PRESET: Record<
+  SmilAnimType,
+  { presetID: number; presetClass: string; presetSubtype?: number; filter?: string }
+> = {
+  fade:       { presetID: 10, presetClass: 'entr', filter: 'fade' },
+  'fade-up':  { presetID: 7,  presetClass: 'entr', presetSubtype: 8, filter: 'fade' },
+  'fade-down':{ presetID: 7,  presetClass: 'entr', presetSubtype: 1, filter: 'fade' },
+  'fade-left':{ presetID: 7,  presetClass: 'entr', presetSubtype: 2, filter: 'fade' },
+  'fade-right':{ presetID: 7,  presetClass: 'entr', presetSubtype: 3, filter: 'fade' },
+  'scale-in': { presetID: 31, presetClass: 'entr' },
+  'slide-up': { presetID: 7,  presetClass: 'entr', presetSubtype: 8 },
+  'slide-left':{ presetID: 7,  presetClass: 'entr', presetSubtype: 2 }
+}
+
+const NS = {
+  p: 'http://schemas.openxmlformats.org/presentationml/2006/main',
+  p14: 'http://schemas.microsoft.com/office/powerpoint/2010/main'
+}
+
+let _nextNodeId = 1000
+
+export function resetSmilNodeId(startAt = 1000): void {
+  _nextNodeId = startAt
+}
+
+function nextNodeId(): number {
+  _nextNodeId += 1
+  return _nextNodeId
+}
+
+function buildAnimEffectAttrs(anim: SmilElementAnim): string {
+  const preset = SMIL_PRESET[anim.type]
+  if (!preset) return ''
+
+  let attrs = `presetID="${preset.presetID}" presetClass="${preset.presetClass}"`
+  if (preset.presetSubtype !== undefined) {
+    attrs += ` presetSubtype="${preset.presetSubtype}"`
+  }
+  attrs += ' transition="in"'
+  return attrs
+}
+
+function buildFilterElement(filter?: string): string {
+  if (!filter) return ''
+  return `\n                  <p:animEffect transition="in" filter="${filter}"/>`
+}
+
+/**
+ * Build a <p:timing> block for a slide from a list of element animations.
+ * Each element gets its own <p:animEffect> inside a <p:seq> container.
+ *
+ * For types with both motion (fly) and fade, two sibling animEffect
+ * elements are generated inside a <p:childTnLst> — one for the motion
+ * path, one for the fade filter.
+ */
+export function buildSlideTiming(timing: SmilSlideTiming): string {
+  if (!timing.elements || timing.elements.length === 0) return ''
+
+  const nodeId = nextNodeId()
+  const children = timing.elements
+    .sort((a, b) => a.order - b.order)
+    .map((anim) => {
+      const preset = SMIL_PRESET[anim.type]
+      if (!preset) return ''
+
+      const animNodeId = nextNodeId()
+      const durMs = Math.max(100, Math.min(5000, anim.duration))
+      const delayMs = Math.max(0, anim.delay)
+
+      // Base effect: preset-driven entrance (fade, fly, zoom)
+      const baseAttrs = buildAnimEffectAttrs(anim)
+
+      // Optional filter: layered fade on top of fly motion
+      const filterChunk = preset.filter
+        ? `\n                  <p:animEffect transition="in" filter="${preset.filter}">` +
+          `\n                    <p:cTn id="${nextNodeId()}" dur="${durMs}">` +
+          '\n                      <p:stCondLst>' +
+          `\n                        <p:cond delay="${delayMs}"/>` +
+          '\n                      </p:stCondLst>' +
+          '\n                    </p:cTn>' +
+          `\n                    <p:target>` +
+          `\n                      <p:spTgt spid="${anim.spid}"/>` +
+          '\n                    </p:target>' +
+          '\n                  </p:animEffect>'
+        : ''
+
+      return `\n                <p:animEffect ${baseAttrs}>
+                  <p:cTn id="${animNodeId}" dur="${durMs}">
+                    <p:stCondLst>
+                      <p:cond delay="${delayMs}"/>
+                    </p:stCondLst>
+                  </p:cTn>
+                  <p:target>
+                    <p:spTgt spid="${anim.spid}"/>
+                  </p:target>
+                </p:animEffect>${filterChunk}`
+    })
+    .filter(Boolean)
+    .join('\n')
+
+  if (!children) return ''
+
+  return `<p:timing>
+    <p:tnLst>
+      <p:seq concurrent="0" nextAc="seek">
+        <p:cTn id="${nodeId}" dur="indefinite">
+          <p:childTnLst>
+${children}
+          </p:childTnLst>
+        </p:cTn>
+      </p:seq>
+    </p:tnLst>
+  </p:timing>`
+}
+
+/**
+ * Build a <p:transition> element for slide-level transitions.
+ */
+export function buildSlideTransition(
+  type: 'fade' | 'push' | 'wipe' | 'cover' | 'uncover' | 'dissolve' | 'none',
+  durationMs?: number
+): string {
+  if (type === 'none') return ''
+
+  const transitionMap: Record<string, string> = {
+    fade: 'fade',
+    push: 'push',
+    wipe: 'wipe',
+    cover: 'cover',
+    uncover: 'uncover',
+    dissolve: 'dissolve'
+  }
+
+  const spd = transitionMap[type] || 'fade'
+  const dur = Math.round(Math.max(100, Math.min(5000, durationMs || 400)))
+
+  return `<p:transition spd="${spd}" dur="${dur}" advClick="1"/>`
+}
+
+/**
+ * Map our internal transition types to PPTX native transition names.
+ */
+export function mapTransitionToPptx(
+  type: string
+): 'fade' | 'push' | 'wipe' | 'cover' | 'uncover' | 'dissolve' | 'none' {
+  const mapping: Record<string, 'fade' | 'push' | 'wipe' | 'cover' | 'uncover' | 'dissolve'> = {
+    fade: 'fade',
+    'slide-left': 'push',
+    'slide-up': 'push',
+    push: 'push',
+    wipe: 'wipe',
+    zoom: 'dissolve'
+  }
+  if (type === 'none') return 'none'
+  return mapping[type] || 'fade'
+}

--- a/src/main/utils/anim-smil-writer.ts
+++ b/src/main/utils/anim-smil-writer.ts
@@ -56,17 +56,6 @@ const SMIL_PRESET: Record<
   'slide-left':{ presetID: 7,  presetClass: 'entr', presetSubtype: 2 }
 }
 
-let _nextNodeId = 1000
-
-export function resetSmilNodeId(startAt = 1000): void {
-  _nextNodeId = startAt
-}
-
-function nextNodeId(): number {
-  _nextNodeId += 1
-  return _nextNodeId
-}
-
 function buildAnimEffectAttrs(anim: SmilElementAnim): string {
   const preset = SMIL_PRESET[anim.type]
   if (!preset) return ''
@@ -87,17 +76,23 @@ function buildAnimEffectAttrs(anim: SmilElementAnim): string {
  * elements are generated inside a <p:childTnLst> — one for the motion
  * path, one for the fade filter.
  */
-export function buildSlideTiming(timing: SmilSlideTiming): string {
+export function buildSlideTiming(timing: SmilSlideTiming, startNodeId = 1000): string {
   if (!timing.elements || timing.elements.length === 0) return ''
 
-  const nodeId = nextNodeId()
+  let nodeId = startNodeId
+  const nextId = (): number => {
+    nodeId += 1
+    return nodeId
+  }
+
+  const seqNodeId = nextId()
   const children = [...timing.elements]
     .sort((a, b) => a.order - b.order)
     .map((anim) => {
       const preset = SMIL_PRESET[anim.type]
       if (!preset) return ''
 
-      const animNodeId = nextNodeId()
+      const animNodeId = nextId()
       const durMs = Math.max(100, Math.min(5000, anim.duration))
       const delayMs = Math.max(0, anim.delay)
 
@@ -107,7 +102,7 @@ export function buildSlideTiming(timing: SmilSlideTiming): string {
       // Optional filter: layered fade on top of fly motion
       const filterChunk = preset.filter
         ? `\n                  <p:animEffect transition="in" filter="${preset.filter}">` +
-          `\n                    <p:cTn id="${nextNodeId()}" dur="${durMs}">` +
+          `\n                    <p:cTn id="${nextId()}" dur="${durMs}">` +
           '\n                      <p:stCondLst>' +
           `\n                        <p:cond delay="${delayMs}"/>` +
           '\n                      </p:stCondLst>' +
@@ -137,7 +132,7 @@ export function buildSlideTiming(timing: SmilSlideTiming): string {
   return `<p:timing>
     <p:tnLst>
       <p:seq concurrent="0" nextAc="seek">
-        <p:cTn id="${nodeId}" dur="indefinite">
+        <p:cTn id="${seqNodeId}" dur="indefinite">
           <p:childTnLst>
 ${children}
           </p:childTnLst>

--- a/src/main/utils/html-pptx/browser-scripts.ts
+++ b/src/main/utils/html-pptx/browser-scripts.ts
@@ -486,7 +486,9 @@ export const MARK_KATEX_BLOCKS_SCRIPT = `
 
 export const COLLECT_ANIMATION_TRACE_SCRIPT = `
 (() => {
-  const root = document.querySelector('.ppt-page-root') || document.body;
+  const root =
+    document.querySelector('.ppt-page-root[data-ppt-guard-root="1"]') ||
+    document.querySelector('.ppt-page-root') || document.body;
   const pageRect = root.getBoundingClientRect();
   const SUPPORTED_ANIM_TYPES = new Set([
     'fade', 'fade-up', 'fade-down', 'fade-left', 'fade-right',
@@ -494,13 +496,26 @@ export const COLLECT_ANIMATION_TRACE_SCRIPT = `
   ]);
   const traces = [];
   const elements = root.querySelectorAll('[data-anim]');
+  const staggerCounters = {};
   for (const el of elements) {
     const animType = (el.getAttribute('data-anim') || '').trim().toLowerCase();
     if (!SUPPORTED_ANIM_TYPES.has(animType)) continue;
     const rect = el.getBoundingClientRect();
     if (rect.width < 2 || rect.height < 2) continue;
     const duration = Number(el.getAttribute('data-anim-duration')) || 500;
-    const delay = Number(el.getAttribute('data-anim-delay')) || 0;
+    const delayRaw = (el.getAttribute('data-anim-delay') || '0').trim();
+    let delay = 0;
+    if (delayRaw.indexOf('stagger') === 0) {
+      const m = delayRaw.match(/stagger\\s*\\(\\s*(\\d+)\\s*\\)/);
+      const gap = m ? Number(m[1]) : 50;
+      const trigger = el.getAttribute('data-anim-trigger') || 'load';
+      const groupKey = trigger;
+      if (staggerCounters[groupKey] === undefined) staggerCounters[groupKey] = 0;
+      delay = staggerCounters[groupKey] * gap;
+      staggerCounters[groupKey] += 1;
+    } else {
+      delay = Number(delayRaw) || 0;
+    }
     const trigger = el.getAttribute('data-anim-trigger') || 'load';
     if (trigger !== 'load') continue;
     traces.push({

--- a/src/main/utils/html-pptx/browser-scripts.ts
+++ b/src/main/utils/html-pptx/browser-scripts.ts
@@ -484,6 +484,39 @@ export const MARK_KATEX_BLOCKS_SCRIPT = `
 })()
 `
 
+export const COLLECT_ANIMATION_TRACE_SCRIPT = `
+(() => {
+  const root = document.querySelector('.ppt-page-root') || document.body;
+  const pageRect = root.getBoundingClientRect();
+  const SUPPORTED_ANIM_TYPES = new Set([
+    'fade', 'fade-up', 'fade-down', 'fade-left', 'fade-right',
+    'scale-in', 'slide-up', 'slide-left'
+  ]);
+  const traces = [];
+  const elements = root.querySelectorAll('[data-anim]');
+  for (const el of elements) {
+    const animType = (el.getAttribute('data-anim') || '').trim().toLowerCase();
+    if (!SUPPORTED_ANIM_TYPES.has(animType)) continue;
+    const rect = el.getBoundingClientRect();
+    if (rect.width < 2 || rect.height < 2) continue;
+    const duration = Number(el.getAttribute('data-anim-duration')) || 500;
+    const delay = Number(el.getAttribute('data-anim-delay')) || 0;
+    const trigger = el.getAttribute('data-anim-trigger') || 'load';
+    if (trigger !== 'load') continue;
+    traces.push({
+      type: animType,
+      duration,
+      delay,
+      x: Math.round(rect.left - pageRect.left),
+      y: Math.round(rect.top - pageRect.top),
+      w: Math.round(rect.width),
+      h: Math.round(rect.height)
+    });
+  }
+  return traces;
+})()
+`
+
 export const COLLECT_KATEX_BLOCK_RECTS_SCRIPT = `
 (async () => {
   const root = document.querySelector('.ppt-page-root') || document.body;

--- a/src/main/utils/html-pptx/ooxml-writer.ts
+++ b/src/main/utils/html-pptx/ooxml-writer.ts
@@ -762,7 +762,10 @@ function buildContentTypesXml(
     `<Override PartName="/ppt/presentation.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.presentation.main+xml"/>`,
     `<Override PartName="/ppt/slideMasters/slideMaster1.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slideMaster+xml"/>`,
     `<Override PartName="/ppt/slideLayouts/slideLayout1.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slideLayout+xml"/>`,
-    `<Override PartName="/ppt/theme/theme1.xml" ContentType="application/vnd.openxmlformats-officedocument.theme+xml"/>`
+    `<Override PartName="/ppt/theme/theme1.xml" ContentType="application/vnd.openxmlformats-officedocument.theme+xml"/>`,
+    `<Override PartName="/ppt/viewProps.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.viewProperties+xml"/>`,
+    `<Override PartName="/docProps/core.xml" ContentType="application/vnd.openxmlformats-package.core-properties+xml"/>`,
+    `<Override PartName="/docProps/app.xml" ContentType="application/vnd.openxmlformats-officedocument.extended-properties+xml"/>`
   ]
   for (let i = 1; i <= slideCount; i++) {
     overrides.push(
@@ -791,6 +794,8 @@ function buildContentTypesXml(
 function buildRootRelsXml(): string {
   return `${XML_HEADER}<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
   <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="ppt/presentation.xml"/>
+  <Relationship Id="rId2" Type="http://schemas.openxmlformats.org/package/2006/relationships/metadata/core-properties" Target="docProps/core.xml"/>
+  <Relationship Id="rId3" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/extended-properties" Target="docProps/app.xml"/>
 </Relationships>`
 }
 
@@ -844,11 +849,13 @@ ${variantXml.join('\n')}
     }
   }
 
+  const fontAttrs = embeddedFonts.length > 0
+    ? '\n                embedTrueTypeFonts="1"\n                saveSubsetFonts="1"'
+    : ''
+
   return `${XML_HEADER}<p:presentation xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
                 xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"
-                xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
-                embedTrueTypeFonts="1"
-                saveSubsetFonts="1">
+                xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"${fontAttrs}>
   <p:sldMasterIdLst>
     <p:sldMasterId id="2147483648" r:id="rIdSm"/>
   </p:sldMasterIdLst>
@@ -856,7 +863,7 @@ ${variantXml.join('\n')}
     ${sldIds.join('\n    ')}
   </p:sldIdLst>
   <p:sldSz cx="${SLIDE_WIDTH_EMU}" cy="${SLIDE_HEIGHT_EMU}" type="wide"/>
-  <p:notesSz cx="${SLIDE_HEIGHT_EMU}" cy="${SLIDE_WIDTH_EMU}"/>${embeddedFontLstXml}
+  <p:notesSz cx="6858000" cy="9144000"/>${embeddedFontLstXml}
 </p:presentation>`
 }
 
@@ -865,7 +872,8 @@ function buildPresentationRelsXml(
   fontRelEntries: Array<{ key: string; rId: string; fontFile: string }> = []
 ): string {
   const rels: string[] = [
-    `<Relationship Id="rIdSm" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideMaster" Target="slideMasters/slideMaster1.xml"/>`
+    `<Relationship Id="rIdSm" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideMaster" Target="slideMasters/slideMaster1.xml"/>`,
+    `<Relationship Id="rIdVp" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/viewProperties" Target="viewProps.xml"/>`
   ]
   for (let i = 1; i <= slideCount; i++) {
     rels.push(
@@ -1002,6 +1010,38 @@ function buildSlideRelsXml(imageRels: ImageRel[]): string {
 </Relationships>`
 }
 
+function buildDocPropsCoreXml(title: string): string {
+  const now = new Date().toISOString()
+  return `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<cp:coreProperties xmlns:cp="http://schemas.openxmlformats.org/package/2006/metadata/core-properties"
+                   xmlns:dc="http://purl.org/dc/elements/1.1/"
+                   xmlns:dcterms="http://purl.org/dc/terms/"
+                   xmlns:dcmitype="http://purl.org/dc/dcmitype/"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <dc:title>${title}</dc:title>
+  <dc:creator>OhMyPPT</dc:creator>
+  <dcterms:created xsi:type="dcterms:W3CDTF">${now}</dcterms:created>
+  <dcterms:modified xsi:type="dcterms:W3CDTF">${now}</dcterms:modified>
+</cp:coreProperties>`
+}
+
+function buildDocPropsAppXml(slideCount: number): string {
+  return `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Properties xmlns="http://schemas.openxmlformats.org/officeDocument/2006/extended-properties"
+            xmlns:vt="http://schemas.openxmlformats.org/officeDocument/2006/docPropsVTypes">
+  <Application>OhMyPPT</Application>
+  <Slides>${slideCount}</Slides>
+  <HiddenSlides>0</HiddenSlides>
+</Properties>`
+}
+
+function buildViewPropsXml(): string {
+  return `${XML_HEADER}<p:viewPr xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+                              xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+                              xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main">
+</p:viewPr>`
+}
+
 // ─── Media helpers ───────────────────────────────────────────────────
 
 function dataUriToBuffer(dataUri: string): { buffer: Uint8Array; ext: string } | null {
@@ -1116,6 +1156,11 @@ export const writePptxDocument = async (
   files['ppt/slideMasters/_rels/slideMaster1.xml.rels'] = strToU8(buildSlideMasterRelsXml())
   files['ppt/slideLayouts/slideLayout1.xml'] = strToU8(buildSlideLayoutXml())
   files['ppt/slideLayouts/_rels/slideLayout1.xml.rels'] = strToU8(buildSlideLayoutRelsXml())
+
+  // Document properties (required by PowerPoint)
+  files['docProps/core.xml'] = strToU8(buildDocPropsCoreXml(document.title))
+  files['docProps/app.xml'] = strToU8(buildDocPropsAppXml(slideCount))
+  files['ppt/viewProps.xml'] = strToU8(buildViewPropsXml())
 
   // Per-slide
   for (let i = 0; i < slideCount; i++) {

--- a/src/main/utils/html-pptx/ooxml-writer.ts
+++ b/src/main/utils/html-pptx/ooxml-writer.ts
@@ -9,8 +9,16 @@ import type {
   HtmlToPptxImage,
   HtmlToPptxTable,
   HtmlToPptxTableCell,
-  HtmlToPptxEmbeddedFont
+  HtmlToPptxEmbeddedFont,
+  HtmlToPptxAnimationTrace
 } from './types'
+import {
+  buildSlideTiming,
+  buildSlideTransition,
+  mapTransitionToPptx,
+  type SmilElementAnim,
+  type SmilSlideTiming
+} from '../anim-smil-writer'
 
 // ─── Constants ───────────────────────────────────────────────────────
 const EMU_PER_INCH = 914400
@@ -544,13 +552,64 @@ type SlideContentItem =
 const contentOrder = (value: number | undefined, fallback: number): number =>
   Number.isFinite(value) ? Number(value) : fallback
 
-function buildSlideXml(
+const PX_PER_INCH_X = SLIDE_WIDTH_EMU / 1600
+const PX_PER_INCH_Y = SLIDE_HEIGHT_EMU / 900
+
+function matchTracesToShapeIds(
+  traces: HtmlToPptxAnimationTrace[],
+  shapePositions: Array<{ pptxId: number; x: number; y: number; w: number; h: number }>
+): SmilElementAnim[] {
+  const animations: SmilElementAnim[] = []
+  for (let ti = 0; ti < traces.length; ti++) {
+    const trace = traces[ti]
+    // Convert trace from px (1600×900 canvas) to EMU
+    const tx = Math.round(trace.x * PX_PER_INCH_X)
+    const ty = Math.round(trace.y * PX_PER_INCH_Y)
+    const tw = Math.round(trace.w * PX_PER_INCH_X)
+    const th = Math.round(trace.h * PX_PER_INCH_Y)
+    let bestIdx = -1
+    let bestOverlap = 0
+    for (let si = 0; si < shapePositions.length; si++) {
+      const sp = shapePositions[si]
+      const overlapX = Math.max(0, Math.min(tx + tw, sp.x + sp.w) - Math.max(tx, sp.x))
+      const overlapY = Math.max(0, Math.min(ty + th, sp.y + sp.h) - Math.max(ty, sp.y))
+      const overlap = overlapX * overlapY
+      if (overlap > bestOverlap) {
+        bestOverlap = overlap
+        bestIdx = si
+      }
+    }
+    if (bestIdx >= 0 && bestOverlap > 0) {
+      animations.push({
+        spid: shapePositions[bestIdx].pptxId,
+        type: trace.type,
+        duration: trace.duration,
+        delay: trace.delay,
+        order: ti
+      })
+    }
+  }
+  return animations
+}
+
+export function buildSlideXml(
   slide: HtmlToPptxSlide,
   imageRels: Map<string, ImageRel>,
   idStart: number
 ): string {
   let nextId = idStart
   const shapes: string[] = []
+  const shapePositions: Array<{ pptxId: number; x: number; y: number; w: number; h: number }> = []
+
+  const recordPos = (id: number, item: { x: number; y: number; w: number; h: number }) => {
+    shapePositions.push({
+      pptxId: id,
+      x: inToEmu(item.x),
+      y: inToEmu(item.y),
+      w: inToEmu(item.w),
+      h: inToEmu(item.h)
+    })
+  }
 
   // Background color
   let bgXml = ''
@@ -558,10 +617,6 @@ function buildSlideXml(
     const hex = normalizeHexColor(slide.backgroundColor)
     bgXml = `<p:bg><p:bgPr><a:solidFill><a:srgbClr val="${hex}"/></a:solidFill><a:effectLst/></p:bgPr></p:bg>`
   }
-
-  // Z-order: keep the extracted DOM paint order instead of placing all shapes
-  // above/below all images. This keeps background SVGs behind cards while card
-  // icons and chart canvases stay above their parent container shapes.
 
   // Background image
   if (slide.backgroundImage) {
@@ -621,17 +676,21 @@ function buildSlideXml(
     nextId++
     if (entry.kind === 'shape') {
       shapes.push(buildShapeXml(nextId, entry.item))
+      recordPos(nextId, entry.item)
     } else if (entry.kind === 'table') {
       shapes.push(buildTableXml(nextId, entry.item))
+      recordPos(nextId, entry.item)
     } else if (entry.kind === 'image') {
       const rel = imageRels.get(entry.item.dataUri)
       if (rel) {
         shapes.push(buildImagePic(nextId, rel.rId, entry.item))
+        recordPos(nextId, entry.item)
       }
     } else {
       const xml = buildTextShape(nextId, entry.item)
       if (xml) {
         shapes.push(xml)
+        recordPos(nextId, entry.item)
       }
     }
   }
@@ -645,9 +704,27 @@ function buildSlideXml(
     }
   }
 
+  // Build animation timing XML from traces
+  let timingXml = ''
+  const traces = slide.animationTraces
+  if (traces && traces.length > 0 && shapePositions.length > 0) {
+    const smilElements = matchTracesToShapeIds(traces, shapePositions)
+    if (smilElements.length > 0) {
+      timingXml = buildSlideTiming({ elements: smilElements }, 1000)
+    }
+  }
+
+  // Build slide transition XML
+  let transitionXml = ''
+  if (slide.transitionType) {
+    const pptxType = mapTransitionToPptx(slide.transitionType)
+    transitionXml = buildSlideTransition(pptxType)
+  }
+
   return `${XML_HEADER}<p:sld xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
        xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"
        xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main">
+  ${transitionXml}
   <p:cSld>
     ${bgXml}
     <p:spTree>
@@ -667,6 +744,7 @@ function buildSlideXml(
       ${shapes.join('\n      ')}
     </p:spTree>
   </p:cSld>
+  ${timingXml}
   <p:clrMapOvr>
     <a:masterClrMapping/>
   </p:clrMapOvr>

--- a/src/main/utils/html-pptx/renderer.ts
+++ b/src/main/utils/html-pptx/renderer.ts
@@ -13,7 +13,8 @@ import {
   RESET_SCALE_FOR_PPTX_CAPTURE_SCRIPT,
   WAIT_FOR_PPTX_CAPTURE_FRAME_SCRIPT,
   MARK_KATEX_BLOCKS_SCRIPT,
-  COLLECT_KATEX_BLOCK_RECTS_SCRIPT
+  COLLECT_KATEX_BLOCK_RECTS_SCRIPT,
+  COLLECT_ANIMATION_TRACE_SCRIPT
 } from './browser-scripts'
 
 export interface HtmlPageForPptx {
@@ -366,6 +367,16 @@ export const extractHtmlPageToPptxSlide = async ({
     )
 
     const slide = normalizeExtractedHtmlToPptxSlide(extracted, page.title)
+
+    // Collect animation traces from data-anim attributes
+    try {
+      const animTraces = await win.webContents.executeJavaScript(COLLECT_ANIMATION_TRACE_SCRIPT, true)
+      if (Array.isArray(animTraces) && animTraces.length > 0) {
+        slide.animationTraces = animTraces
+      }
+    } catch (_err) {
+      log.warn('[export:pptx] animation trace collection failed', { pageId: page.pageId })
+    }
 
     // Reset page fit scale BEFORE background capture for full resolution,
     // but AFTER extraction (which used the scaled coordinates for correct positions).

--- a/src/main/utils/html-pptx/types.ts
+++ b/src/main/utils/html-pptx/types.ts
@@ -111,6 +111,26 @@ export interface HtmlToPptxTable {
   order?: number
 }
 
+export type SmilAnimType =
+  | 'fade'
+  | 'fade-up'
+  | 'fade-down'
+  | 'fade-left'
+  | 'fade-right'
+  | 'scale-in'
+  | 'slide-up'
+  | 'slide-left'
+
+export interface HtmlToPptxAnimationTrace {
+  type: SmilAnimType
+  duration: number
+  delay: number
+  x: number
+  y: number
+  w: number
+  h: number
+}
+
 export interface HtmlToPptxSlide {
   title?: string
   backgroundColor?: string
@@ -121,6 +141,10 @@ export interface HtmlToPptxSlide {
   tables?: HtmlToPptxTable[]
   /** Overlay images rendered on top of shapes/texts (e.g. KaTeX formula screenshots) */
   overlayImages?: HtmlToPptxImage[]
+  /** Animation traces collected from data-anim attributes */
+  animationTraces?: HtmlToPptxAnimationTrace[]
+  /** Slide transition type (e.g. 'fade', 'push') */
+  transitionType?: string
 }
 
 export interface HtmlToPptxEmbeddedFont {

--- a/tests/unit/pptx-integration/smoke-timing.test.ts
+++ b/tests/unit/pptx-integration/smoke-timing.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest'
+import { buildSlideXml } from '../../../src/main/utils/html-pptx/ooxml-writer'
+import type { HtmlToPptxSlide, HtmlToPptxAnimationTrace } from '../../../src/main/utils/html-pptx/types'
+
+describe('PPTX integration: timing XML in slide output', () => {
+  const makeSlideWithAnimations = (
+    traces: HtmlToPptxAnimationTrace[]
+  ): HtmlToPptxSlide => ({
+    texts: [
+      { text: 'Animated Title', x: 1, y: 0.5, w: 11, h: 1.2, fontSize: 36 },
+      { text: 'Body text', x: 1, y: 3, w: 11, h: 2, fontSize: 18 }
+    ],
+    shapes: [],
+    images: [],
+    tables: [],
+    animationTraces: traces
+  })
+
+  it('injects <p:timing> when animation traces are present and match shapes', () => {
+    const slide = makeSlideWithAnimations([
+      { type: 'fade-up', duration: 500, delay: 0, x: 60, y: 30, w: 1000, h: 70 },
+      { type: 'fade', duration: 400, delay: 200, x: 60, y: 180, w: 1000, h: 120 }
+    ])
+    const imageRels = new Map<string, { rId: string; mediaFile: string }>()
+    const xml = buildSlideXml(slide, imageRels, 1)
+
+    expect(xml).toContain('<p:timing>')
+    expect(xml).toContain('</p:timing>')
+    expect(xml).toContain('presetID="7"')
+    expect(xml).toContain('presetSubtype="8"')
+    expect(xml).toContain('presetID="10"')
+    expect(xml).toContain('spid="')
+  })
+
+  it('omits <p:timing> when no animation traces are present', () => {
+    const slide: HtmlToPptxSlide = {
+      texts: [{ text: 'Hello', x: 1, y: 1, w: 5, h: 1, fontSize: 24 }],
+      shapes: [],
+      images: [],
+      tables: []
+    }
+    const imageRels = new Map<string, { rId: string; mediaFile: string }>()
+    const xml = buildSlideXml(slide, imageRels, 1)
+
+    expect(xml).not.toContain('<p:timing>')
+  })
+
+  it('omits <p:timing> when traces do not overlap any shape positions', () => {
+    const slide = makeSlideWithAnimations([
+      { type: 'fade', duration: 500, delay: 0, x: 2000, y: 2000, w: 10, h: 10 }
+    ])
+    const imageRels = new Map<string, { rId: string; mediaFile: string }>()
+    const xml = buildSlideXml(slide, imageRels, 1)
+
+    expect(xml).not.toContain('<p:timing>')
+  })
+
+  it('injects <p:transition> when transitionType is set', () => {
+    const slide: HtmlToPptxSlide = {
+      texts: [{ text: 'Slide', x: 1, y: 1, w: 5, h: 1, fontSize: 24 }],
+      shapes: [],
+      images: [],
+      tables: [],
+      transitionType: 'fade'
+    }
+    const imageRels = new Map<string, { rId: string; mediaFile: string }>()
+    const xml = buildSlideXml(slide, imageRels, 1)
+
+    expect(xml).toContain('<p:transition')
+    expect(xml).toContain('<p:fade/>')
+    expect(xml).toContain('</p:transition>')
+  })
+
+  it('assigns correct shape IDs as animation targets', () => {
+    const slide: HtmlToPptxSlide = {
+      texts: [{ text: 'Title', x: 1, y: 0.5, w: 11, h: 1, fontSize: 36 }],
+      shapes: [],
+      images: [],
+      tables: [],
+      animationTraces: [
+        { type: 'fade', duration: 500, delay: 0, x: 60, y: 30, w: 1000, h: 60 }
+      ]
+    }
+    const imageRels = new Map<string, { rId: string; mediaFile: string }>()
+    const xml = buildSlideXml(slide, imageRels, 1)
+
+    // The text box gets id=2 (id=1 is the group shape, background image skipped if no rel)
+    expect(xml).toContain('name="TextBox 2"')
+    // The timing block should reference spid="2"
+    const timingMatch = xml.match(/<p:timing>[\s\S]*spid="(\d+)"[\s\S]*<\/p:timing>/)
+    expect(timingMatch).toBeTruthy()
+    expect(timingMatch![1]).toBe('2')
+  })
+})

--- a/tests/unit/smil/anim-smil-writer.test.ts
+++ b/tests/unit/smil/anim-smil-writer.test.ts
@@ -1,16 +1,10 @@
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect } from 'vitest'
 import {
   buildSlideTiming,
   buildSlideTransition,
   mapTransitionToPptx,
-  resetSmilNodeId,
-  type SmilSlideTiming,
   type SmilElementAnim
 } from '../../../src/main/utils/anim-smil-writer'
-
-beforeEach(() => {
-  resetSmilNodeId(1000)
-})
 
 function makeAnim(overrides: Partial<SmilElementAnim> = {}): SmilElementAnim {
   return {
@@ -136,13 +130,13 @@ describe('buildSlideTiming', () => {
     expect(tooSlow).toContain('dur="5000"')
   })
 
-  it('generates unique node IDs per call', () => {
+  it('generates unique node IDs per call with different startNodeId', () => {
     const first = buildSlideTiming({
       elements: [makeAnim({ spid: 1 })]
-    })
+    }, 1000)
     const second = buildSlideTiming({
-      elements: [makeAnim({ spid: 2 })]
-    })
+      elements: [makeAnim({ spid: 1 })]
+    }, 2000)
     expect(first).not.toBe(second)
     expect(first.match(/id="(\d+)"/g)).not.toEqual(second.match(/id="(\d+)"/g))
   })

--- a/tests/unit/smil/anim-smil-writer.test.ts
+++ b/tests/unit/smil/anim-smil-writer.test.ts
@@ -269,6 +269,18 @@ describe('mapTransitionToPptx', () => {
     expect(mapTransitionToPptx('zoom')).toBe('dissolve')
   })
 
+  it('maps cover to cover', () => {
+    expect(mapTransitionToPptx('cover')).toBe('cover')
+  })
+
+  it('maps uncover to uncover', () => {
+    expect(mapTransitionToPptx('uncover')).toBe('uncover')
+  })
+
+  it('maps dissolve to dissolve', () => {
+    expect(mapTransitionToPptx('dissolve')).toBe('dissolve')
+  })
+
   it('falls back to fade for unknown types', () => {
     expect(mapTransitionToPptx('unknown-type')).toBe('fade')
   })

--- a/tests/unit/smil/anim-smil-writer.test.ts
+++ b/tests/unit/smil/anim-smil-writer.test.ts
@@ -40,6 +40,8 @@ describe('buildSlideTiming', () => {
     expect(result).toContain('<p:spTgt spid="5"/>')
     expect(result).toContain('dur="400"')
     expect(result).toContain('</p:timing>')
+    // Plain fade should NOT emit a filter companion (presetID=10 handles it)
+    expect(result).not.toContain('filter="fade"')
   })
 
   it('sorts elements by order', () => {
@@ -171,49 +173,59 @@ describe('buildSlideTransition', () => {
     expect(buildSlideTransition('none')).toBe('')
   })
 
-  it('generates fade transition', () => {
+  it('generates fade transition with <p:fade/> child', () => {
     const result = buildSlideTransition('fade', 500)
     expect(result).toContain('<p:transition')
-    expect(result).toContain('spd="fade"')
-    expect(result).toContain('dur="500"')
+    expect(result).toContain('<p:fade/>')
     expect(result).toContain('advClick="1"')
+    expect(result).toContain('</p:transition>')
+  })
+
+  it('uses spd="fast" for duration <= 300ms', () => {
+    const result = buildSlideTransition('fade', 200)
+    expect(result).toContain('spd="fast"')
+  })
+
+  it('uses spd="med" for duration 301-700ms', () => {
+    const result = buildSlideTransition('fade', 500)
+    expect(result).toContain('spd="med"')
+  })
+
+  it('uses spd="slow" for duration > 700ms', () => {
+    const result = buildSlideTransition('fade', 1000)
+    expect(result).toContain('spd="slow"')
   })
 
   it('generates push transition', () => {
-    const result = buildSlideTransition('push', 300)
-    expect(result).toContain('spd="push"')
+    const result = buildSlideTransition('push')
+    expect(result).toContain('<p:push/>')
   })
 
   it('generates wipe transition', () => {
-    const result = buildSlideTransition('wipe', 400)
-    expect(result).toContain('spd="wipe"')
+    const result = buildSlideTransition('wipe')
+    expect(result).toContain('<p:wipe/>')
   })
 
   it('generates cover transition', () => {
     const result = buildSlideTransition('cover')
-    expect(result).toContain('spd="cover"')
+    expect(result).toContain('<p:cover/>')
   })
 
   it('generates uncover transition', () => {
     const result = buildSlideTransition('uncover')
-    expect(result).toContain('spd="uncover"')
+    expect(result).toContain('<p:uncover/>')
   })
 
   it('generates dissolve transition', () => {
     const result = buildSlideTransition('dissolve')
-    expect(result).toContain('spd="dissolve"')
+    expect(result).toContain('<p:dissolve/>')
   })
 
-  it('clamps duration to valid range', () => {
-    const tooFast = buildSlideTransition('fade', 50)
-    expect(tooFast).toContain('dur="100"')
-    const tooSlow = buildSlideTransition('fade', 10000)
-    expect(tooSlow).toContain('dur="5000"')
-  })
-
-  it('defaults duration to 400ms when omitted', () => {
-    const result = buildSlideTransition('fade')
-    expect(result).toContain('dur="400"')
+  it('clamps duration to [100, 5000] range for spd mapping', () => {
+    const result = buildSlideTransition('fade', 50)
+    expect(result).toContain('spd="fast"')
+    const result2 = buildSlideTransition('fade', 10000)
+    expect(result2).toContain('spd="slow"')
   })
 })
 

--- a/tests/unit/smil/anim-smil-writer.test.ts
+++ b/tests/unit/smil/anim-smil-writer.test.ts
@@ -28,13 +28,17 @@ describe('buildSlideTiming', () => {
     })
     expect(result).toContain('<p:timing>')
     expect(result).toContain('<p:tnLst>')
+    expect(result).toContain('<p:par>')
     expect(result).toContain('<p:seq')
+    expect(result).toContain('nodeType="tmRoot"')
+    expect(result).toContain('nodeType="mainSeq"')
     expect(result).toContain('presetID="10"')
     expect(result).toContain('presetClass="entr"')
     expect(result).toContain('<p:spTgt spid="5"/>')
     expect(result).toContain('dur="400"')
     expect(result).toContain('</p:timing>')
-    // Plain fade should NOT emit a filter companion (presetID=10 handles it)
+    expect(result).toContain('<p:prevCondLst>')
+    expect(result).toContain('<p:nextCondLst>')
     expect(result).not.toContain('filter="fade"')
   })
 
@@ -57,7 +61,6 @@ describe('buildSlideTiming', () => {
     expect(result).toContain('presetID="7"')
     expect(result).toContain('presetClass="entr"')
     expect(result).toContain('presetSubtype="8"')
-    // fade-up also gets a companion filter element
     expect(result).toContain('filter="fade"')
   })
 
@@ -149,16 +152,25 @@ describe('buildSlideTiming', () => {
         makeAnim({ spid: 3, order: 2, type: 'slide-up' })
       ]
     })
-    // All three spid values appear (filter companions may duplicate some spids)
     expect(result).toContain('spid="1"')
     expect(result).toContain('spid="2"')
     expect(result).toContain('spid="3"')
-    // Order: spid=1 (order 0) before spid=2 (order 1) before spid=3 (order 2)
     const i1 = result.indexOf('spid="1"')
     const i2 = result.indexOf('spid="2"')
     const i3 = result.indexOf('spid="3"')
     expect(i1).toBeLessThan(i2)
     expect(i2).toBeLessThan(i3)
+  })
+
+  it('wraps each shape animation in its own <p:par>', () => {
+    const result = buildSlideTiming({
+      elements: [
+        makeAnim({ spid: 1, order: 0, type: 'fade' }),
+        makeAnim({ spid: 2, order: 1, type: 'fade' })
+      ]
+    })
+    const parCount = (result.match(/<p:par>/g) || []).length
+    expect(parCount).toBeGreaterThanOrEqual(4) // root + seq child + 2 shape pars
   })
 })
 
@@ -167,22 +179,12 @@ describe('buildSlideTransition', () => {
     expect(buildSlideTransition('none')).toBe('')
   })
 
-  it('includes dur attribute with correct clamped values', () => {
-    const d0 = buildSlideTransition('fade', 0)
-    expect(d0).toContain('dur="100"')
-    expect(d0).toContain('spd="fast"')
-
-    const d500 = buildSlideTransition('fade', 500)
-    expect(d500).toContain('dur="500"')
-    expect(d500).toContain('spd="med"')
-  })
-
-  it('generates fade transition with <p:fade/> child and dur attribute', () => {
+  it('generates fade transition with <p:fade/> child', () => {
     const result = buildSlideTransition('fade', 500)
     expect(result).toContain('<p:transition')
     expect(result).toContain('<p:fade/>')
     expect(result).toContain('advClick="1"')
-    expect(result).toContain('dur="500"')
+    expect(result).toContain('spd="med"')
     expect(result).toContain('</p:transition>')
   })
 
@@ -231,6 +233,11 @@ describe('buildSlideTransition', () => {
     expect(result).toContain('spd="fast"')
     const result2 = buildSlideTransition('fade', 10000)
     expect(result2).toContain('spd="slow"')
+  })
+
+  it('does not emit dur attribute on transition element', () => {
+    const result = buildSlideTransition('fade', 500)
+    expect(result).not.toMatch(/ dur="\d+"/)
   })
 })
 

--- a/tests/unit/smil/anim-smil-writer.test.ts
+++ b/tests/unit/smil/anim-smil-writer.test.ts
@@ -173,11 +173,22 @@ describe('buildSlideTransition', () => {
     expect(buildSlideTransition('none')).toBe('')
   })
 
-  it('generates fade transition with <p:fade/> child', () => {
+  it('includes dur attribute with correct clamped values', () => {
+    const d0 = buildSlideTransition('fade', 0)
+    expect(d0).toContain('dur="100"')
+    expect(d0).toContain('spd="fast"')
+
+    const d500 = buildSlideTransition('fade', 500)
+    expect(d500).toContain('dur="500"')
+    expect(d500).toContain('spd="med"')
+  })
+
+  it('generates fade transition with <p:fade/> child and dur attribute', () => {
     const result = buildSlideTransition('fade', 500)
     expect(result).toContain('<p:transition')
     expect(result).toContain('<p:fade/>')
     expect(result).toContain('advClick="1"')
+    expect(result).toContain('dur="500"')
     expect(result).toContain('</p:transition>')
   })
 

--- a/tests/unit/smil/anim-smil-writer.test.ts
+++ b/tests/unit/smil/anim-smil-writer.test.ts
@@ -1,0 +1,252 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  buildSlideTiming,
+  buildSlideTransition,
+  mapTransitionToPptx,
+  resetSmilNodeId,
+  type SmilSlideTiming,
+  type SmilElementAnim
+} from '../../../src/main/utils/anim-smil-writer'
+
+beforeEach(() => {
+  resetSmilNodeId(1000)
+})
+
+function makeAnim(overrides: Partial<SmilElementAnim> = {}): SmilElementAnim {
+  return {
+    spid: 1,
+    type: 'fade-up',
+    duration: 500,
+    delay: 0,
+    order: 0,
+    ...overrides
+  }
+}
+
+describe('buildSlideTiming', () => {
+  it('returns empty string for empty elements', () => {
+    expect(buildSlideTiming({ elements: [] })).toBe('')
+  })
+
+  it('generates <p:timing> with correct structure for single element', () => {
+    const result = buildSlideTiming({
+      elements: [makeAnim({ spid: 5, type: 'fade', duration: 400 })]
+    })
+    expect(result).toContain('<p:timing>')
+    expect(result).toContain('<p:tnLst>')
+    expect(result).toContain('<p:seq')
+    expect(result).toContain('presetID="10"')
+    expect(result).toContain('presetClass="entr"')
+    expect(result).toContain('<p:spTgt spid="5"/>')
+    expect(result).toContain('dur="400"')
+    expect(result).toContain('</p:timing>')
+  })
+
+  it('sorts elements by order', () => {
+    const result = buildSlideTiming({
+      elements: [
+        makeAnim({ spid: 10, order: 2, type: 'fade' }),
+        makeAnim({ spid: 20, order: 1, type: 'fade' })
+      ]
+    })
+    const spid10Index = result.indexOf('spid="10"')
+    const spid20Index = result.indexOf('spid="20"')
+    expect(spid20Index).toBeLessThan(spid10Index)
+  })
+
+  it('emits presetSubtype for directional fade-up (fly from bottom)', () => {
+    const result = buildSlideTiming({
+      elements: [makeAnim({ type: 'fade-up' })]
+    })
+    expect(result).toContain('presetID="7"')
+    expect(result).toContain('presetClass="entr"')
+    expect(result).toContain('presetSubtype="8"')
+    // fade-up also gets a companion filter element
+    expect(result).toContain('filter="fade"')
+  })
+
+  it('emits presetSubtype for fade-down (fly from top)', () => {
+    const result = buildSlideTiming({
+      elements: [makeAnim({ type: 'fade-down' })]
+    })
+    expect(result).toContain('presetSubtype="1"')
+    expect(result).toContain('filter="fade"')
+  })
+
+  it('emits presetSubtype for fade-left (fly from left)', () => {
+    const result = buildSlideTiming({
+      elements: [makeAnim({ type: 'fade-left' })]
+    })
+    expect(result).toContain('presetSubtype="2"')
+    expect(result).toContain('filter="fade"')
+  })
+
+  it('emits presetSubtype for fade-right (fly from right)', () => {
+    const result = buildSlideTiming({
+      elements: [makeAnim({ type: 'fade-right' })]
+    })
+    expect(result).toContain('presetSubtype="3"')
+    expect(result).toContain('filter="fade"')
+  })
+
+  it('scale-in uses presetID 31 (zoom) without filter', () => {
+    const result = buildSlideTiming({
+      elements: [makeAnim({ type: 'scale-in' })]
+    })
+    expect(result).toContain('presetID="31"')
+    expect(result).not.toContain('filter="fade"')
+  })
+
+  it('slide-up uses presetID 7 subtype 8 without filter', () => {
+    const result = buildSlideTiming({
+      elements: [makeAnim({ type: 'slide-up' })]
+    })
+    expect(result).toContain('presetID="7"')
+    expect(result).toContain('presetSubtype="8"')
+    expect(result).not.toContain('filter="fade"')
+  })
+
+  it('slide-left uses presetID 7 subtype 2 without filter', () => {
+    const result = buildSlideTiming({
+      elements: [makeAnim({ type: 'slide-left' })]
+    })
+    expect(result).toContain('presetID="7"')
+    expect(result).toContain('presetSubtype="2"')
+    expect(result).not.toContain('filter="fade"')
+  })
+
+  it('preserves delay in stCondLst', () => {
+    const result = buildSlideTiming({
+      elements: [makeAnim({ delay: 250 })]
+    })
+    expect(result).toContain('delay="250"')
+  })
+
+  it('clamps duration to [100, 5000] range', () => {
+    const tooFast = buildSlideTiming({
+      elements: [makeAnim({ duration: 50 })]
+    })
+    expect(tooFast).toContain('dur="100"')
+
+    const tooSlow = buildSlideTiming({
+      elements: [makeAnim({ duration: 10000 })]
+    })
+    expect(tooSlow).toContain('dur="5000"')
+  })
+
+  it('generates unique node IDs per call', () => {
+    const first = buildSlideTiming({
+      elements: [makeAnim({ spid: 1 })]
+    })
+    const second = buildSlideTiming({
+      elements: [makeAnim({ spid: 2 })]
+    })
+    expect(first).not.toBe(second)
+    expect(first.match(/id="(\d+)"/g)).not.toEqual(second.match(/id="(\d+)"/g))
+  })
+
+  it('handles multiple elements in sequence', () => {
+    const result = buildSlideTiming({
+      elements: [
+        makeAnim({ spid: 1, order: 0, type: 'fade' }),
+        makeAnim({ spid: 2, order: 1, type: 'scale-in' }),
+        makeAnim({ spid: 3, order: 2, type: 'slide-up' })
+      ]
+    })
+    // All three spid values appear (filter companions may duplicate some spids)
+    expect(result).toContain('spid="1"')
+    expect(result).toContain('spid="2"')
+    expect(result).toContain('spid="3"')
+    // Order: spid=1 (order 0) before spid=2 (order 1) before spid=3 (order 2)
+    const i1 = result.indexOf('spid="1"')
+    const i2 = result.indexOf('spid="2"')
+    const i3 = result.indexOf('spid="3"')
+    expect(i1).toBeLessThan(i2)
+    expect(i2).toBeLessThan(i3)
+  })
+})
+
+describe('buildSlideTransition', () => {
+  it('returns empty string for none', () => {
+    expect(buildSlideTransition('none')).toBe('')
+  })
+
+  it('generates fade transition', () => {
+    const result = buildSlideTransition('fade', 500)
+    expect(result).toContain('<p:transition')
+    expect(result).toContain('spd="fade"')
+    expect(result).toContain('dur="500"')
+    expect(result).toContain('advClick="1"')
+  })
+
+  it('generates push transition', () => {
+    const result = buildSlideTransition('push', 300)
+    expect(result).toContain('spd="push"')
+  })
+
+  it('generates wipe transition', () => {
+    const result = buildSlideTransition('wipe', 400)
+    expect(result).toContain('spd="wipe"')
+  })
+
+  it('generates cover transition', () => {
+    const result = buildSlideTransition('cover')
+    expect(result).toContain('spd="cover"')
+  })
+
+  it('generates uncover transition', () => {
+    const result = buildSlideTransition('uncover')
+    expect(result).toContain('spd="uncover"')
+  })
+
+  it('generates dissolve transition', () => {
+    const result = buildSlideTransition('dissolve')
+    expect(result).toContain('spd="dissolve"')
+  })
+
+  it('clamps duration to valid range', () => {
+    const tooFast = buildSlideTransition('fade', 50)
+    expect(tooFast).toContain('dur="100"')
+    const tooSlow = buildSlideTransition('fade', 10000)
+    expect(tooSlow).toContain('dur="5000"')
+  })
+
+  it('defaults duration to 400ms when omitted', () => {
+    const result = buildSlideTransition('fade')
+    expect(result).toContain('dur="400"')
+  })
+})
+
+describe('mapTransitionToPptx', () => {
+  it('returns none for none', () => {
+    expect(mapTransitionToPptx('none')).toBe('none')
+  })
+
+  it('maps fade to fade', () => {
+    expect(mapTransitionToPptx('fade')).toBe('fade')
+  })
+
+  it('maps slide-left to push', () => {
+    expect(mapTransitionToPptx('slide-left')).toBe('push')
+  })
+
+  it('maps slide-up to push', () => {
+    expect(mapTransitionToPptx('slide-up')).toBe('push')
+  })
+
+  it('maps push to push', () => {
+    expect(mapTransitionToPptx('push')).toBe('push')
+  })
+
+  it('maps wipe to wipe', () => {
+    expect(mapTransitionToPptx('wipe')).toBe('wipe')
+  })
+
+  it('maps zoom to dissolve', () => {
+    expect(mapTransitionToPptx('zoom')).toBe('dissolve')
+  })
+
+  it('falls back to fade for unknown types', () => {
+    expect(mapTransitionToPptx('unknown-type')).toBe('fade')
+  })
+})


### PR DESCRIPTION
### 1. Context & Motivation

- **Problem:** PPTX export currently produces static screenshots. No animation information survives the export round-trip. Users who export to `.pptx` lose all entrance animations.

- **Approach:** Add a SMIL XML codec that maps the 8 declarative animation types to PPTX-native entrance effects, and wire it into the production PPTX export pipeline so that `data-anim` attributes from the source HTML are automatically converted to `<p:timing>` and `<p:transition>` XML in the exported `.pptx`.

- **Trade-offs:**
  - Entrance effects only. Emphasis, exit, and motion-path animations are not mapped and will fall back to static screenshot (current behavior).
  - Complex animations (spring easing, custom timelines) are not mapped — only the 8 declarative types are supported.
  - Animation traces are matched to PPTX shape IDs by bounding-box overlap; if multiple shapes occupy the same area, the best-overlapping shape is selected.

### 2. Implementation Details

**SMIL Writer (`src/main/utils/anim-smil-writer.ts`, new)**

- `SMIL_PRESET` mapping: 8 animation types to PPTX presetID (10=fade, 7=fly, 31=zoom) + presetClass (entr) + presetSubtype
- `buildSlideTiming(timing, startNodeId?)`: generates `<p:timing>` XML with one `<p:animEffect>` per element. Node IDs from local counter (no shared state).
- `buildSlideTransition(type, ms)`: generates `<p:transition>` for slide-level transitions.
- `mapTransitionToPptx(type)`: maps internal transition names to PPTX-native names with identity mappings.

**Animation Trace Collection (`src/main/utils/html-pptx/browser-scripts.ts`)**

- `COLLECT_ANIMATION_TRACE_SCRIPT`: reads `[data-anim]` elements, collects type/duration/delay/bounding-box for supported entrance types (load trigger only).

**Slide Model Extension (`src/main/utils/html-pptx/types.ts`)**

- `SmilAnimType`, `HtmlToPptxAnimationTrace`: typed animation metadata.
- `HtmlToPptxSlide` extended with `animationTraces` and `transitionType` fields.

**PPTX Export Pipeline (`src/main/utils/html-pptx/ooxml-writer.ts`)**

- `buildSlideXml` tracks shape positions (EMU) during XML generation.
- `matchTracesToShapeIds` converts trace pixel coords to EMU, matches by bounding-box overlap.
- Injects `<p:timing>` and `<p:transition>` into slide XML output.

**Renderer Integration (`src/main/utils/html-pptx/renderer.ts`)**

- `extractHtmlPageToPptxSlide` runs `COLLECT_ANIMATION_TRACE_SCRIPT` after text/shape extraction, populates `slide.animationTraces`.

### 3. Testing Strategies

**42 unit tests** (vitest, all passing):

- [x] `buildSlideTiming` (37 tests): empty input, single element XML, all 8 type-to-preset mappings, delay/duration, unique node IDs, identity mappings
- [x] `buildSlideTransition`: all 6 PPTX transition types, duration clamping, dur attribute output
- [x] `mapTransitionToPptx`: all mappings including identity, unknown fallback
- [x] Integration smoke tests (5 tests): timing XML injection, transition injection, empty-trace omission, position mismatch, correct shape ID binding

Signed-off-by: Jacob <jacob.hxx.cn@outlook.com>