### PR TITLE
fix(speech): address remaining review comments after #82 merge

### DIFF
--- a/src/main/ipc/speech/speech-handlers.ts
+++ b/src/main/ipc/speech/speech-handlers.ts
@@ -5,13 +5,12 @@ import * as cheerio from 'cheerio'
 import { HumanMessage, SystemMessage } from '@langchain/core/messages'
 import log from 'electron-log/main.js'
 import { resolveModelTimeoutMs } from '@shared/model-timeout'
+import type { SpeechLength, SpeechStyle } from '@shared/speech'
 import type { IpcContext } from '../context'
 import { resolveActiveModelConfig, resolveGlobalModelTimeouts } from '../config/model-config-utils'
 import { resolveModel } from '../../agent'
 import { readAppLocale, uiText } from '../config/locale-utils'
-
-export type SpeechLength = 'short' | 'medium' | 'long'
-export type SpeechStyle = 'formal' | 'conversational' | 'storytelling' | 'custom'
+import { extractModelText } from '../utils'
 
 const SPEECH_SCRIPT_FILE = 'speech-script.md'
 
@@ -101,6 +100,8 @@ function buildStyleInstruction(style: SpeechStyle, isZh: boolean, customStyle?: 
   }
 }
 
+const activeSpeechGenerations = new Set<string>()
+
 export function registerSpeechHandlers(ctx: IpcContext): void {
   ipcMain.handle('speech:generateScript', async (event, payload) => {
     const sessionId = typeof payload?.sessionId === 'string' ? payload.sessionId.trim() : ''
@@ -125,78 +126,94 @@ export function registerSpeechHandlers(ctx: IpcContext): void {
       throw new Error(uiText(locale, '单页模式需要提供当前页面 ID', 'currentPageId is required for single-page scope'))
     }
 
-    const session = await ctx.db.getSession(sessionId)
-    if (!session) {
-      throw new Error(uiText(locale, '找不到会话', 'Session not found'))
+    if (activeSpeechGenerations.has(sessionId)) {
+      throw new Error(uiText(locale, '正在生成中，请稍候', 'Generation already in progress'))
     }
+    activeSpeechGenerations.add(sessionId)
 
-    const pages = await ctx.db.listSessionPages(sessionId)
-    if (pages.length === 0) {
-      throw new Error(uiText(locale, '该会话没有幻灯片页面', 'No pages found in this session'))
-    }
-
-    const projectDir = await ctx.resolveSessionProjectDir(sessionId)
-
-    const filteredPages =
-      scope === 'single' && currentPageId ? pages.filter((p) => p.id === currentPageId) : pages
-
-    if (filteredPages.length === 0) {
-      throw new Error(uiText(locale, '找不到指定页面', 'Specified page not found'))
-    }
-
-    const slideContents: Array<{ pageNumber: number; title: string; text: string }> = []
-    for (const p of filteredPages) {
-      if (!p.html_path) continue
-      const htmlPath = path.isAbsolute(p.html_path)
-        ? path.resolve(p.html_path)
-        : path.resolve(projectDir, p.html_path)
-      if (!ctx.isPathInside(htmlPath, projectDir)) {
-        log.warn('[speech] skipping page with unsafe htmlPath', { htmlPath, projectDir })
-        continue
-      }
-      try {
-        const html = await fs.promises.readFile(htmlPath, 'utf-8')
-        const text = extractTextFromHtml(html)
-        if (text) {
-          slideContents.push({ pageNumber: p.page_number, title: p.title || '', text })
-        }
-      } catch (err) {
-        log.warn('[speech] failed to read page html', { htmlPath: p.html_path, err })
-      }
-    }
-
-    if (slideContents.length === 0) {
-      throw new Error(uiText(locale, '没有可读取的幻灯片内容', 'No readable slide content found'))
-    }
-
-    const modelConfig = await resolveActiveModelConfig(ctx)
-    const timeouts = await resolveGlobalModelTimeouts(ctx)
-    const timeoutMs = resolveModelTimeoutMs(timeouts['document'], 'document')
-    const model = resolveModel(
-      modelConfig.provider,
-      modelConfig.apiKey,
-      modelConfig.model,
-      modelConfig.baseUrl,
-      0.7,
-      modelConfig.maxTokens
-    )
-
-    const lengthInstruction = buildLengthInstruction(length, isZh)
-    const styleInstruction = buildStyleInstruction(style, isZh, customStyle)
-    const total = slideContents.length
-    const sessionTitle = session.title || session.topic || (isZh ? '未命名' : 'Untitled')
-
-    // Clear existing script before generation so stale data is never shown on failure
-    const scriptPath = path.join(projectDir, SPEECH_SCRIPT_FILE)
     try {
-      await fs.promises.unlink(scriptPath)
-    } catch {
-      // file may not exist yet
-    }
+      const session = await ctx.db.getSession(sessionId)
+      if (!session) {
+        throw new Error(uiText(locale, '找不到会话', 'Session not found'))
+      }
 
-    const systemPrompt = uiText(
-      locale,
-      `你是一位经验丰富的演讲稿撰写人，擅长将幻灯片内容转化为自然流畅、打动人心的演讲词。
+      const pages = await ctx.db.listSessionPages(sessionId)
+      if (pages.length === 0) {
+        throw new Error(uiText(locale, '该会话没有幻灯片页面', 'No pages found in this session'))
+      }
+
+      const projectDir = await ctx.resolveSessionProjectDir(sessionId)
+
+      const filteredPages =
+        scope === 'single' && currentPageId ? pages.filter((p) => p.id === currentPageId) : pages
+
+      if (filteredPages.length === 0) {
+        throw new Error(uiText(locale, '找不到指定页面', 'Specified page not found'))
+      }
+
+      const slideContents: Array<{ pageNumber: number; title: string; text: string }> = []
+      for (const p of filteredPages) {
+        if (!p.html_path) continue
+        const rawHtmlPath = path.isAbsolute(p.html_path)
+          ? p.html_path
+          : path.resolve(projectDir, p.html_path)
+        let safeHtmlPath: string
+        try {
+          safeHtmlPath = await ctx.assertPathInAllowedRoots({
+            filePath: rawHtmlPath,
+            mode: 'read',
+            sessionId,
+            htmlOnly: true
+          })
+        } catch {
+          log.warn('[speech] skipping page with unsafe htmlPath', { rawHtmlPath, projectDir })
+          continue
+        }
+        try {
+          const html = await fs.promises.readFile(safeHtmlPath, 'utf-8')
+          const text = extractTextFromHtml(html)
+          slideContents.push({
+            pageNumber: p.page_number,
+            title: p.title || '',
+            text: text || uiText(locale, '（本页主要为图片或视觉内容，请结合上下文发挥）', '(This slide is mainly visual; improvise based on context.)')
+          })
+        } catch (err) {
+          log.warn('[speech] failed to read page html', { htmlPath: p.html_path, err })
+        }
+      }
+
+      if (slideContents.length === 0) {
+        throw new Error(uiText(locale, '没有可读取的幻灯片内容', 'No readable slide content found'))
+      }
+
+      const modelConfig = await resolveActiveModelConfig(ctx)
+      const timeouts = await resolveGlobalModelTimeouts(ctx)
+      const timeoutMs = resolveModelTimeoutMs(timeouts['document'], 'document')
+      const model = resolveModel(
+        modelConfig.provider,
+        modelConfig.apiKey,
+        modelConfig.model,
+        modelConfig.baseUrl,
+        0.7,
+        modelConfig.maxTokens
+      )
+
+      const lengthInstruction = buildLengthInstruction(length, isZh)
+      const styleInstruction = buildStyleInstruction(style, isZh, customStyle)
+      const total = slideContents.length
+      const sessionTitle = session.title || session.topic || (isZh ? '未命名' : 'Untitled')
+
+      // Clear existing script before generation so stale data is never shown on failure
+      const scriptPath = path.join(projectDir, SPEECH_SCRIPT_FILE)
+      try {
+        await fs.promises.unlink(scriptPath)
+      } catch {
+        // file may not exist yet
+      }
+
+      const systemPrompt = uiText(
+        locale,
+        `你是一位经验丰富的演讲稿撰写人，擅长将幻灯片内容转化为自然流畅、打动人心的演讲词。
 
 **任务规则：**
 - 每次仅为当前一页幻灯片生成演讲稿，不要提前引用后续页面内容。
@@ -212,7 +229,7 @@ ${styleInstruction}
 
 **页面衔接：**
 如提供了上一页的结尾内容，请在开头自然地加入过渡语句，使演讲整体连贯，不显突兀。`,
-      `You are an experienced speech writer who transforms slide content into natural, compelling spoken words.
+        `You are an experienced speech writer who transforms slide content into natural, compelling spoken words.
 
 **Rules:**
 - Generate speaker notes for the current slide only. Do not reference future slides.
@@ -228,33 +245,33 @@ ${styleInstruction}
 
 **Transitions:**
 If the previous slide's ending is provided, open with a smooth transition sentence that connects the two slides naturally.`
-    )
+      )
 
-    const scriptParts: string[] = []
-    let prevEnding = ''
+      const scriptParts: string[] = []
+      let prevEnding = ''
 
-    for (let i = 0; i < slideContents.length; i++) {
-      const slide = slideContents[i]
-      const current = i + 1
-      event.sender.send('speech:progress', { sessionId, current, total })
+      for (let i = 0; i < slideContents.length; i++) {
+        const slide = slideContents[i]
+        const current = i + 1
+        event.sender.send('speech:progress', { sessionId, current, total })
 
-      const contextPart = prevEnding
-        ? uiText(locale, `上一页结尾：${prevEnding}\n\n`, `Previous slide ending: ${prevEnding}\n\n`)
-        : ''
+        const contextPart = prevEnding
+          ? uiText(locale, `上一页结尾：${prevEnding}\n\n`, `Previous slide ending: ${prevEnding}\n\n`)
+          : ''
 
-      // Use generation index for progress position; include original slide number for context
-      const positionZh =
-        total === 1
-          ? `第 ${slide.pageNumber} 页`
-          : `第 ${current} / ${total} 页（原始页码：第 ${slide.pageNumber} 页）`
-      const positionEn =
-        total === 1
-          ? `Slide ${slide.pageNumber}`
-          : `Slide ${current} of ${total} (original page number: ${slide.pageNumber})`
+        // Use generation index for progress position; include original slide number for context
+        const positionZh =
+          total === 1
+            ? `第 ${slide.pageNumber} 页`
+            : `第 ${current} / ${total} 页（原始页码：第 ${slide.pageNumber} 页）`
+        const positionEn =
+          total === 1
+            ? `Slide ${slide.pageNumber}`
+            : `Slide ${current} of ${total} (original page number: ${slide.pageNumber})`
 
-      const userPrompt = uiText(
-        locale,
-        `${contextPart}【演示文稿】${sessionTitle}
+        const userPrompt = uiText(
+          locale,
+          `${contextPart}【演示文稿】${sessionTitle}
 【当前位置】${positionZh}
 【本页标题】${slide.title || '（无标题）'}
 
@@ -262,7 +279,7 @@ If the previous slide's ending is provided, open with a smooth transition senten
 ${slide.text}
 
 请为本页生成演讲稿。`,
-        `${contextPart}[Presentation] ${sessionTitle}
+          `${contextPart}[Presentation] ${sessionTitle}
 [Position] ${positionEn}
 [Slide Title] ${slide.title || '(no title)'}
 
@@ -270,26 +287,31 @@ ${slide.text}
 ${slide.text}
 
 Please generate the speaker script for this slide.`
-      )
+        )
 
-      log.info('[speech] generating slide', { sessionId, current, total })
+        log.info('[speech] generating slide', { sessionId, current, total })
 
-      const response = await model.invoke(
-        [new SystemMessage(systemPrompt), new HumanMessage(userPrompt)],
-        { signal: AbortSignal.timeout(timeoutMs) }
-      )
-      const part =
-        typeof response.content === 'string' ? response.content : JSON.stringify(response.content)
-      scriptParts.push(part)
+        const response = await model.invoke(
+          [new SystemMessage(systemPrompt), new HumanMessage(userPrompt)],
+          { signal: AbortSignal.timeout(timeoutMs) }
+        )
+        const part = extractModelText(response).trim()
+        if (!part) {
+          throw new Error(uiText(locale, '模型返回为空', 'Model returned empty content'))
+        }
+        scriptParts.push(part)
 
-      prevEnding = part.slice(-100).replace(/\s+/g, ' ').trim()
+        prevEnding = part.slice(-100).replace(/\s+/g, ' ').trim()
+      }
+
+      const script = scriptParts.join('\n\n---\n\n')
+      await fs.promises.writeFile(scriptPath, script, 'utf-8')
+
+      log.info('[speech] script saved', { sessionId, scriptPath })
+      return { success: true }
+    } finally {
+      activeSpeechGenerations.delete(sessionId)
     }
-
-    const script = scriptParts.join('\n\n---\n\n')
-    await fs.promises.writeFile(scriptPath, script, 'utf-8')
-
-    log.info('[speech] script saved', { sessionId, scriptPath })
-    return { success: true }
   })
 
   ipcMain.handle('speech:getScript', async (_event, payload) => {

--- a/src/renderer/src/components/session-detail/SpeechScriptDrawer.tsx
+++ b/src/renderer/src/components/session-detail/SpeechScriptDrawer.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { Check, Copy, Download, Loader2, X } from 'lucide-react'
 import { cn } from '@renderer/lib/utils'
 import { Button } from '../ui/Button'
@@ -11,17 +11,9 @@ import {
 } from '../ui/Select'
 import { useT } from '@renderer/i18n'
 import { ipc } from '@renderer/lib/ipc'
+import type { SpeechConfig, SpeechLength, SpeechScope, SpeechStyle } from '@shared/speech'
 
-type SpeechScope = 'all' | 'single'
-type SpeechLength = 'short' | 'medium' | 'long'
-type SpeechStyle = 'formal' | 'conversational' | 'storytelling' | 'custom'
-
-export interface SpeechConfig {
-  scope: SpeechScope
-  length: SpeechLength
-  style: SpeechStyle
-  customStyle?: string
-}
+export type { SpeechConfig }
 
 interface SpeechScriptDrawerProps {
   sessionId: string
@@ -51,29 +43,31 @@ export function SpeechScriptDrawer({
   const [script, setScript] = useState<string | null>(null)
   const [copied, setCopied] = useState(false)
 
-  const loadScript = (switchTab: boolean): void => {
-    void ipc
-      .getSpeechScript(sessionId)
-      .then((result) => {
-        if (result.script) {
-          setScript(result.script)
-          if (switchTab) setTab('result')
-        } else {
+  const loadScript = useCallback(
+    (switchTab: boolean): void => {
+      void ipc
+        .getSpeechScript(sessionId)
+        .then((result) => {
+          if (result.script) {
+            setScript(result.script)
+            if (switchTab) setTab('result')
+          } else {
+            setScript(null)
+            if (switchTab) setTab('config')
+          }
+        })
+        .catch(() => {
           setScript(null)
           if (switchTab) setTab('config')
-        }
-      })
-      .catch(() => {
-        setScript(null)
-        if (switchTab) setTab('config')
-      })
-  }
+        })
+    },
+    [sessionId]
+  )
 
   // Load on mount / session change
   useEffect(() => {
     loadScript(true)
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [sessionId])
+  }, [loadScript])
 
   // Reload after generation finishes (skip initial render via ref)
   const isFirstRender = useRef(true)
@@ -85,8 +79,7 @@ export function SpeechScriptDrawer({
     if (!isGenerating) {
       loadScript(false)
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isGenerating])
+  }, [isGenerating, loadScript])
 
   const handleCopy = async (): Promise<void> => {
     if (!script) return

--- a/src/renderer/src/lib/ipc.ts
+++ b/src/renderer/src/lib/ipc.ts
@@ -13,7 +13,7 @@ import type {
   UploadedAsset
 } from '@shared/generation.js'
 import type { UpdateAvailablePayload } from '@shared/app-update.js'
-import type { SpeechConfig } from '@renderer/components/session-detail/SpeechScriptDrawer'
+import type { SpeechConfig } from '@shared/speech'
 import type { HistoryVersion, RollbackHistoryResult } from '@shared/history.js'
 import type {
   ThinkingStage,

--- a/src/renderer/src/pages/session-detail.tsx
+++ b/src/renderer/src/pages/session-detail.tsx
@@ -39,6 +39,7 @@ import { useSessionDetailUiStore } from '../store/sessionDetailStore'
 import { useEditHistoryStore } from '../store/editHistoryStore'
 import type { GenerateChunkEvent } from '@shared/generation.js'
 import type { HistoryVersion } from '@shared/history.js'
+import type { SpeechConfig } from '@shared/speech'
 import { useToastStore } from '../store'
 import { getEditorGate } from '../lib/sessionMetadata'
 import { useT } from '../i18n'
@@ -724,7 +725,7 @@ export function SessionDetailPage(): React.JSX.Element {
         latestPages[latestPages.length - 1]
       targetSelection = (addedPage || fallbackPage)?.id ?? null
       // Only clear script on success — a new page invalidates the existing script
-      if (id) void ipc.clearSpeechScript(id)
+      if (id) void ipc.clearSpeechScript(id).catch((err) => console.warn('[speech] clearSpeechScript failed', err))
     } catch (err) {
       const message = err instanceof Error ? err.message : t('sessionDetail.addPageFailed')
       toastError(message)
@@ -749,7 +750,7 @@ export function SessionDetailPage(): React.JSX.Element {
       useGenerateStore.getState().setPages(result.generatedPages)
       useSessionDetailUiStore.getState().setSelectedPageId(result.selectedPageId)
       useSessionDetailUiStore.getState().bumpPreviewKey()
-      void ipc.clearSpeechScript(id)
+      void ipc.clearSpeechScript(id).catch((err) => console.warn('[speech] clearSpeechScript failed', err))
     } catch (error) {
       toastError(error instanceof Error ? error.message : t('pageManagement.reorderFailed'))
     } finally {
@@ -775,7 +776,7 @@ export function SessionDetailPage(): React.JSX.Element {
       useSessionDetailUiStore.getState().setSelectedPageId(result.selectedPageId)
       useSessionDetailUiStore.getState().bumpPreviewKey()
       setDeleteConfirmPage(null)
-      void ipc.clearSpeechScript(id)
+      void ipc.clearSpeechScript(id).catch((err) => console.warn('[speech] clearSpeechScript failed', err))
     } catch (error) {
       toastError(error instanceof Error ? error.message : t('pageManagement.deleteFailed'))
     } finally {
@@ -827,12 +828,7 @@ export function SessionDetailPage(): React.JSX.Element {
     useSessionDetailUiStore.getState().setSpeechScriptDialogOpen(true)
   }
 
-  const handleDoGenerateSpeechScript = async (config: {
-    scope: 'all' | 'single'
-    length: 'short' | 'medium' | 'long'
-    style: 'formal' | 'conversational' | 'storytelling' | 'custom'
-    customStyle?: string
-  }): Promise<void> => {
+  const handleDoGenerateSpeechScript = async (config: SpeechConfig): Promise<void> => {
     const detailState = useSessionDetailUiStore.getState()
     if (!id || detailState.isGeneratingSpeechScript) return
     detailState.setIsGeneratingSpeechScript(true)
@@ -1729,9 +1725,9 @@ export function SessionDetailPage(): React.JSX.Element {
                   setDeleteConfirmOpen(true)
                 }}
               />
-              {speechScriptDialogOpen && (
+              {speechScriptDialogOpen && id && (
                 <SpeechScriptDrawer
-                  sessionId={id || ''}
+                  sessionId={id}
                   isGenerating={isGeneratingSpeechScript}
                   speechProgress={speechProgress}
                   speechConfig={speechConfig}

--- a/src/renderer/src/store/sessionDetailStore.ts
+++ b/src/renderer/src/store/sessionDetailStore.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand'
 import type { UploadedAsset } from '@shared/generation.js'
-import type { SpeechConfig } from '@renderer/components/session-detail/SpeechScriptDrawer'
+import type { SpeechConfig } from '@shared/speech'
 
 export type SessionDetailChatType = 'main' | 'page'
 export type InteractionMode = 'preview' | 'ai-inspect' | 'edit'
@@ -207,6 +207,7 @@ export const useSessionDetailUiStore = create<SessionDetailUiStore>((set) => ({
       assetPickerOpen: false,
       isGeneratingSpeechScript: false,
       speechProgress: null,
-      speechScriptDialogOpen: false
+      speechScriptDialogOpen: false,
+      speechConfig: { scope: 'all' as const, length: 'medium' as const, style: 'conversational' as const }
     })
 }))

--- a/src/shared/speech.ts
+++ b/src/shared/speech.ts
@@ -1,0 +1,10 @@
+export type SpeechScope = 'all' | 'single'
+export type SpeechLength = 'short' | 'medium' | 'long'
+export type SpeechStyle = 'formal' | 'conversational' | 'storytelling' | 'custom'
+
+export interface SpeechConfig {
+  scope: SpeechScope
+  length: SpeechLength
+  style: SpeechStyle
+  customStyle?: string
+}


### PR DESCRIPTION
## Summary

Follow-up to #82. Addresses all review comments that arrived after the PR was merged.

**Type safety**
- Move `SpeechConfig` / `SpeechLength` / `SpeechStyle` / `SpeechScope` to `src/shared/speech.ts` — single source of truth for both main process and renderer; removes duplicate definitions in `SpeechScriptDrawer`, `ipc.ts`, and `session-detail.tsx`

**Security**
- Replace `ctx.isPathInside` with `ctx.assertPathInAllowedRoots` when reading slide HTML files — resolves symlinks before path validation (P1 from owner review)

**Correctness**
- Use `extractModelText()` instead of `JSON.stringify` for LLM response content — prevents raw `ContentBlock[]` JSON leaking into the script file (P1 from owner review)
- Add `activeSpeechGenerations` Set to prevent concurrent generation for the same session — lock acquired before any `await`, released in `finally` (P2 from owner review)
- Include image-only / text-free slides with a placeholder so `total` in progress events matches the actual page count instead of only text-bearing slides
- Guard `<SpeechScriptDrawer>` render with `id` check — avoids calling `ipc.getSpeechScript('')` when session id is not yet available
- Reset `speechConfig` in `resetForSessionChange` so settings don't carry over between sessions

**Code quality**
- `loadScript` wrapped in `useCallback([sessionId])` — removes two `eslint-disable-next-line react-hooks/exhaustive-deps` suppressions
- Add `.catch(err => console.warn(...))` on the three fire-and-forget `clearSpeechScript` calls

## Test plan

- [ ] Generate speech script for a deck with image-only slides — progress should show correct total
- [ ] Rapid-click generate twice — second call should be rejected with "already in progress"
- [ ] Switching sessions resets style/length/scope config to defaults
- [ ] Type-check passes: `pnpm typecheck`

🤖 Generated with [Claude Code](https://claude.com/claude-code)