### PR TITLE
feat: add OrcaRouter as a named model provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,21 @@ Oh My PPT 的页面是 HTML 幻灯片，支持 16+ 种页面切换动画，并�
 - Ollama 配置用于文本生成、文档解析和编辑对话；需要生图或自动配图时，请在「设置 → 生图模型」另行配置支持图片生成的 Provider。
 
 
+<a id="orcarouter"></a>
+## 🐋 接入 OrcaRouter 网关
+
+[OrcaRouter](https://www.orcarouter.ai) 是一个 OpenAI 兼容的 AI 网关，通过一个端点、一把 Key 即可路由 160+ 款来自各大厂商的模型。它在同一端点上还提供面向 AI Agent 的网关级零信任安全防护——默认拒绝地筛查每条 prompt/response、管控每一次工具调用，无需改动应用代码。
+
+在「设置 → 文本模型」添加模型时这样填写：
+
+- `provider`: `orcarouter`
+- `base_url`: `https://api.orcarouter.ai/v1`
+- `model`: 任意网关模型名，例如 `orcarouter/auto`（自动为请求路由到最优模型）
+- `api_key`: 你的 OrcaRouter Key（前缀 `sk-orca-`）
+
+选择 OrcaRouter 预设会自动填入网关端点与 `orcarouter/auto` 模型别名；点击「验证」会真实请求一次 `https://api.orcarouter.ai/v1`。与其他 OpenAI 兼容 `base_url` 一样，网关端点按自定义端点处理，兼容性 thinking 参数会自动处理。
+
+
 <a id="usage-notes"></a>
 ## 关于使用问题汇总
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -229,6 +229,20 @@ Notes:
 - Official OpenAI endpoints do not receive the non-standard `thinking` parameter, avoiding `400 Unknown parameter` responses. Other OpenAI-compatible `base_url` values still request disabled thinking so multi-turn tool flows do not lose `reasoning_content`.
 - The Ollama setup is for text generation, document parsing, and chat editing. Configure an image-capable provider separately under **Settings → Image Models** for image generation or automatic visuals.
 
+<a id="orcarouter"></a>
+## 🐋 OrcaRouter Gateway Support
+
+[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible AI gateway that routes to 160+ models from leading providers through one endpoint and one key. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.
+
+In **Settings → Text Models**, add a model with:
+
+- `provider`: `orcarouter`
+- `base_url`: `https://api.orcarouter.ai/v1`
+- `model`: any gateway model, for example `orcarouter/auto` (auto-routes to the best model for the request)
+- `api_key`: your OrcaRouter key (prefix `sk-orca-`)
+
+The OrcaRouter preset pre-fills the gateway endpoint and the `orcarouter/auto` model alias, and verification runs a real request against `https://api.orcarouter.ai/v1`. Like other OpenAI-compatible `base_url` values, the gateway endpoint is treated as a custom endpoint so compatibility thinking parameters are handled automatically.
+
 <a id="usage-notes"></a>
 ## Usage Notes
 

--- a/src/main/agent-runtime/model/options.ts
+++ b/src/main/agent-runtime/model/options.ts
@@ -78,3 +78,34 @@ export const buildOpenAIModelOptions = ({
 export const isOpenAIResponsesProvider = (provider: string): boolean => {
   return provider === 'openai-responses'
 }
+
+export const ORCAROUTER_BASE_URL = 'https://api.orcarouter.ai/v1'
+export const ORCAROUTER_DEFAULT_MODEL = 'orcarouter/auto'
+
+export const isOrcaRouterProvider = (provider: string): boolean => {
+  return provider === 'orcarouter'
+}
+
+export const buildOrcaRouterModelOptions = ({
+  model,
+  apiKey,
+  baseUrl,
+  temperatureOptions,
+  maxTokens,
+  thinkingParameterMode = DEFAULT_THINKING_PARAMETER_MODE
+}: {
+  model: string
+  apiKey: string
+  baseUrl?: string
+  temperatureOptions: { temperature?: number }
+  maxTokens: number
+  thinkingParameterMode?: ThinkingParameterMode
+}): ReturnType<typeof buildOpenAIModelOptions> =>
+  buildOpenAIModelOptions({
+    model,
+    apiKey,
+    baseUrl: baseUrl?.trim() || ORCAROUTER_BASE_URL,
+    temperatureOptions,
+    maxTokens,
+    thinkingParameterMode
+  })

--- a/src/main/agent-runtime/model/resolve.ts
+++ b/src/main/agent-runtime/model/resolve.ts
@@ -5,6 +5,7 @@ import { ChatOpenAICompletions } from '@langchain/openai'
 import log from 'electron-log/main.js'
 import {
   buildOpenAIModelOptions,
+  buildOrcaRouterModelOptions,
   isOpenAIResponsesProvider,
   normalizeOpenAIBaseUrl,
   resolveOpenAIThinkingModelKwargs
@@ -40,9 +41,15 @@ export function resolveModel(
   const resolvedMaxTokens = maxTokens && maxTokens > 0 ? maxTokens : 4096
   const useOpenAIResponsesApi = isOpenAIResponsesProvider(provider)
   const openAIProtocol =
-    provider === 'openai' ? 'chat-completions' : useOpenAIResponsesApi ? 'responses' : undefined
+    provider === 'openai' || provider === 'orcarouter'
+      ? 'chat-completions'
+      : useOpenAIResponsesApi
+        ? 'responses'
+        : undefined
   const openAIThinkingModelKwargs =
-    provider === 'openai' || provider === 'openai-responses'
+    provider === 'openai' ||
+    provider === 'openai-responses' ||
+    provider === 'orcarouter'
       ? resolveOpenAIThinkingModelKwargs({
           baseUrl: normalizeOpenAIBaseUrl(resolvedBaseUrl, useOpenAIResponsesApi),
           useResponsesApi: useOpenAIResponsesApi,
@@ -91,6 +98,18 @@ export function resolveModel(
           temperatureOptions,
           maxTokens: resolvedMaxTokens,
           useResponsesApi: true,
+          thinkingParameterMode
+        }),
+        callbacks: [usageCallback]
+      })
+    case 'orcarouter':
+      return new ChatOpenAICompletions({
+        ...buildOrcaRouterModelOptions({
+          model: resolvedModel,
+          apiKey,
+          baseUrl: resolvedBaseUrl,
+          temperatureOptions,
+          maxTokens: resolvedMaxTokens,
           thinkingParameterMode
         }),
         callbacks: [usageCallback]

--- a/src/main/config/settings-handlers.ts
+++ b/src/main/config/settings-handlers.ts
@@ -28,7 +28,13 @@ const readGlobalTimeouts = (
     ])
   ) as Record<ConfigurableModelTimeoutProfile, number>
 
-const VALID_PROVIDERS = ['anthropic', 'openai', 'openai-responses', 'google'] as const
+const VALID_PROVIDERS = [
+  'anthropic',
+  'openai',
+  'openai-responses',
+  'orcarouter',
+  'google'
+] as const
 type Provider = (typeof VALID_PROVIDERS)[number]
 const normalizeProvider = (provider: unknown): Provider =>
   VALID_PROVIDERS.includes(provider as Provider) ? (provider as Provider) : 'openai'

--- a/src/renderer/src/components/settings/ModelConfigDialog.tsx
+++ b/src/renderer/src/components/settings/ModelConfigDialog.tsx
@@ -15,7 +15,8 @@ const MODEL_PROVIDER_LINKS = [
   { label: 'MiniMax', url: 'https://www.minimaxi.com/' },
   { label: 'OpenAI', url: 'https://platform.openai.com' },
   { label: 'Claude (Anthropic)', url: 'https://console.anthropic.com' },
-  { label: 'Google Gemini', url: 'https://ai.google.dev' }
+  { label: 'Google Gemini', url: 'https://ai.google.dev' },
+  { label: 'OrcaRouter', url: 'https://www.orcarouter.ai' }
 ]
 
 interface ModelConfigDialogProps {
@@ -101,9 +102,16 @@ export function ModelConfigDialog({
                     provider:
                       value === 'anthropic' ||
                       value === 'google' ||
-                      value === 'openai-responses'
+                      value === 'openai-responses' ||
+                      value === 'orcarouter'
                         ? value
-                        : 'openai'
+                        : 'openai',
+                    ...(value === 'orcarouter'
+                      ? {
+                          baseUrl: 'https://api.orcarouter.ai/v1',
+                          model: 'orcarouter/auto'
+                        }
+                      : {})
                   })
                 }
               >
@@ -118,6 +126,7 @@ export function ModelConfigDialog({
                   <SelectItem value="openai-responses">
                     {t('settings.providerOpenAIResponses')}
                   </SelectItem>
+                  <SelectItem value="orcarouter">OrcaRouter</SelectItem>
                   <SelectItem value="google">Google Gemini</SelectItem>
                 </SelectContent>
               </Select>
@@ -170,9 +179,11 @@ export function ModelConfigDialog({
                 provider:
                   form.provider === 'openai' || form.provider === 'openai-responses'
                     ? 'OpenAI'
-                    : form.provider === 'google'
-                      ? 'Google'
-                      : 'Claude'
+                    : form.provider === 'orcarouter'
+                      ? 'OrcaRouter'
+                      : form.provider === 'google'
+                        ? 'Google'
+                        : 'Claude'
               })}
               value={form.apiKey}
               onChange={(e) => onFormChange({ apiKey: e.target.value })}
@@ -215,7 +226,7 @@ export function ModelConfigDialog({
             />
           </div>
 
-          {form.provider === 'openai' && (
+          {form.provider === 'openai' || form.provider === 'orcarouter' ? (
             <div className="rounded-lg border border-[#e3d8c5] bg-[#fffdf8]/70 p-3">
               <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
                 <span className="min-w-0">
@@ -248,7 +259,7 @@ export function ModelConfigDialog({
                 </Select>
               </div>
             </div>
-          )}
+          ) : null}
         </div>
 
         <div className="flex justify-end gap-2 border-t border-[#e3d8c5] px-5 py-3.5">

--- a/src/renderer/src/components/settings/ModelSettingsTab.tsx
+++ b/src/renderer/src/components/settings/ModelSettingsTab.tsx
@@ -15,7 +15,8 @@ const MODEL_PROVIDER_LINKS = [
   { label: 'MiniMax', url: 'https://www.minimaxi.com/' },
   { label: 'OpenAI', url: 'https://platform.openai.com' },
   { label: 'Claude (Anthropic)', url: 'https://console.anthropic.com' },
-  { label: 'Google Gemini', url: 'https://ai.google.dev' }
+  { label: 'Google Gemini', url: 'https://ai.google.dev' },
+  { label: 'OrcaRouter', url: 'https://www.orcarouter.ai' }
 ]
 
 interface ModelSettingsTabProps {

--- a/src/renderer/src/components/settings/types.ts
+++ b/src/renderer/src/components/settings/types.ts
@@ -3,7 +3,7 @@ import type { ThinkingParameterMode } from '@shared/model-config.js'
 import type { I18nKey, TranslationParams } from '../../i18n'
 import type { ImageModelProvider } from '../../lib/ipc'
 
-export type ProviderId = 'anthropic' | 'openai' | 'openai-responses' | 'google'
+export type ProviderId = 'anthropic' | 'openai' | 'openai-responses' | 'orcarouter' | 'google'
 
 export type SettingsTranslate = (key: I18nKey, params?: TranslationParams) => string
 

--- a/src/renderer/src/lib/ipc.ts
+++ b/src/renderer/src/lib/ipc.ts
@@ -429,7 +429,7 @@ export interface SaveSessionAsNewResult {
 export interface ModelConfig {
   id: string
   name: string
-  provider: 'anthropic' | 'openai' | 'openai-responses' | 'google'
+  provider: 'anthropic' | 'openai' | 'openai-responses' | 'orcarouter' | 'google'
   model: string
   apiKey: string
   baseUrl: string
@@ -1119,7 +1119,7 @@ export const ipc = {
   upsertModelConfig: (payload: {
     id?: string
     name: string
-    provider: 'anthropic' | 'openai' | 'openai-responses' | 'google'
+    provider: 'anthropic' | 'openai' | 'openai-responses' | 'orcarouter' | 'google'
     model: string
     apiKey: string
     baseUrl: string

--- a/src/renderer/src/store/settingsStore.ts
+++ b/src/renderer/src/store/settingsStore.ts
@@ -29,7 +29,7 @@ interface SettingsStore {
   upsertModelConfig: (config: {
     id?: string
     name: string
-    provider: 'anthropic' | 'openai' | 'openai-responses' | 'google'
+    provider: 'anthropic' | 'openai' | 'openai-responses' | 'orcarouter' | 'google'
     model: string
     apiKey: string
     baseUrl: string

--- a/tests/unit/ipc/settings-handlers.test.ts
+++ b/tests/unit/ipc/settings-handlers.test.ts
@@ -286,6 +286,30 @@ describe('registerSettingsHandlers model temperature settings', () => {
     )
   })
 
+  it('accepts the OrcaRouter provider when saving a model config', async () => {
+    const upsertModelConfig = vi.fn(async () => 'model-1')
+    const { getHandler } = await registerWithDb({ upsertModelConfig })
+
+    const saveModelConfig = getHandler('settings:upsertModelConfig')
+    await saveModelConfig?.(undefined, {
+      name: 'OrcaRouter model',
+      provider: 'orcarouter',
+      model: 'orcarouter/auto',
+      apiKey: 'sk-orca-',
+      baseUrl: 'https://api.orcarouter.ai/v1',
+      maxTokens: 4096,
+      disableTemperature: false,
+      thinkingParameterMode: 'not-valid'
+    })
+
+    expect(upsertModelConfig).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: 'orcarouter',
+        thinkingParameterMode: 'auto'
+      })
+    )
+  })
+
   it('explains invalid Responses API payloads during model verification', async () => {
     settingsHandlersState.localeMock.readAppLocale.mockResolvedValue('zh')
     settingsHandlersState.resolveModelMock.mockReturnValue({

--- a/tests/unit/openai-model-options.test.ts
+++ b/tests/unit/openai-model-options.test.ts
@@ -1,9 +1,55 @@
 import { describe, expect, it } from 'vitest'
 import {
   buildOpenAIModelOptions,
+  buildOrcaRouterModelOptions,
   normalizeOpenAIBaseUrl,
+  ORCAROUTER_BASE_URL,
+  ORCAROUTER_DEFAULT_MODEL,
   resolveOpenAIThinkingModelKwargs
 } from '../../src/main/agent-runtime/model'
+
+describe('buildOrcaRouterModelOptions', () => {
+  it('defaults to the OrcaRouter gateway endpoint and model alias', () => {
+    expect(
+      buildOrcaRouterModelOptions({
+        model: ORCAROUTER_DEFAULT_MODEL,
+        apiKey: 'secret',
+        temperatureOptions: { temperature: 0.7 },
+        maxTokens: 4096
+      })
+    ).toEqual({
+      model: 'orcarouter/auto',
+      apiKey: 'secret',
+      temperature: 0.7,
+      maxTokens: 4096,
+      configuration: { baseURL: 'https://api.orcarouter.ai/v1' },
+      modelKwargs: { thinking: { type: 'disabled' } }
+    })
+  })
+
+  it('honors an explicit base_url override', () => {
+    expect(
+      buildOrcaRouterModelOptions({
+        model: 'orcarouter/auto',
+        apiKey: 'secret',
+        baseUrl: 'https://gateway.example.com/v1/',
+        temperatureOptions: {},
+        maxTokens: 2048
+      })
+    ).toEqual({
+      model: 'orcarouter/auto',
+      apiKey: 'secret',
+      maxTokens: 2048,
+      configuration: { baseURL: 'https://gateway.example.com/v1' },
+      modelKwargs: { thinking: { type: 'disabled' } }
+    })
+  })
+
+  it('exposes the official gateway constant', () => {
+    expect(ORCAROUTER_BASE_URL).toBe('https://api.orcarouter.ai/v1')
+    expect(ORCAROUTER_DEFAULT_MODEL).toBe('orcarouter/auto')
+  })
+})
 
 describe('buildOpenAIModelOptions', () => {
   it.each(['', 'https://api.openai.com', 'https://api.openai.com/v1', 'https://API.OPENAI.COM/v1/'])(


### PR DESCRIPTION
feat: add OrcaRouter as a named model provider

Add [OrcaRouter](https://www.orcarouter.ai) as a first-class, named text-model provider in Oh My PPT. OrcaRouter is an OpenAI-compatible AI gateway that exposes 160+ models from leading providers through one endpoint and one key. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

**What changed**

- `src/main/agent-runtime/model/options.ts` — add `ORCAROUTER_BASE_URL` (`https://api.orcarouter.ai/v1`), `ORCAROUTER_DEFAULT_MODEL` (`orcarouter/auto`), and `buildOrcaRouterModelOptions` (reuses the existing OpenAI-compatible Chat Completions wiring; respects an explicit `base_url` override and defaults to the gateway endpoint).
- `src/main/agent-runtime/model/resolve.ts` — resolve `orcarouter` to `ChatOpenAICompletions` with the gateway defaults, logging it as a Chat Completions provider with compatibility thinking handling.
- `src/main/config/settings-handlers.ts` — accept `orcarouter` in `VALID_PROVIDERS` so save/verify normalize it (falls back to `openai` for any unknown value, as before).
- Settings UI (`ModelConfigDialog.tsx`, `ModelSettingsTab.tsx`, `types.ts`, `lib/ipc.ts`, `settingsStore.ts`) — add **OrcaRouter** to the provider preset dropdown and the provider-help links; selecting it pre-fills `base_url: https://api.orcarouter.ai/v1` and `model: orcarouter/auto`; the thinking-parameter control applies to it like the OpenAI Chat Completions preset.
- README (`README.md`, `README_EN.md`) — document the OrcaRouter preset with the gateway endpoint and `orcarouter/auto` model alias.
- Tests — cover `buildOrcaRouterModelOptions` defaults/override and the `orcarouter` provider save path.

**Verification**

- `pnpm run typecheck` (node + web): pass.
- `vitest run`: 1155 passed; the only failure (`prompt-inventory.test.ts` missing `docs/design/...md`) and the 4 `html-pptx/*` failures are pre-existing environment issues on clean `main` (missing sibling `html2pptx` source).
- L3 live test: `resolveModel('orcarouter', <real key>, 'orcarouter/auto')` invoked `https://api.orcarouter.ai/v1` successfully through the exact production code path.
- New code adds no new ESLint errors.

Disclosure: I'm an engineer on the OrcaRouter team.
