### PR TITLE
feat(image-generation): 新增 OpenAI Images API 生图协议

### DIFF
--- a/src/main/agent-runtime/provider/image/providers/index.ts
+++ b/src/main/agent-runtime/provider/image/providers/index.ts
@@ -4,6 +4,7 @@ import { geminiAdapter } from './gemini'
 import { jimengAdapter } from './jimeng'
 import { jimengV4Adapter } from './jimeng-v4'
 import { openAiChatCompletionsAdapter } from './openai-chat-completions'
+import { openAiImagesAdapter } from './openai-images'
 import { seedreamAdapter } from './seedream'
 import { siliconFlowAdapter } from './siliconflow'
 
@@ -16,6 +17,7 @@ const PROVIDER_ADAPTERS: Record<
   jimeng4: jimengV4Adapter,
   siliconflow: siliconFlowAdapter,
   openaiCompatible: openAiChatCompletionsAdapter,
+  openaiImages: openAiImagesAdapter,
   gemini: geminiAdapter,
   seedream: seedreamAdapter
 }

--- a/src/main/agent-runtime/provider/image/providers/openai-images.ts
+++ b/src/main/agent-runtime/provider/image/providers/openai-images.ts
@@ -1,0 +1,163 @@
+import log from 'electron-log/main.js'
+import type {
+  ImageGenerationProviderAdapter,
+  ImageGenerationResult,
+  ResolvedImageModelConfig
+} from '../types'
+import { collectImageResults, joinUrl, readRecord, readString } from './utils'
+
+const DEFAULT_BASE_URL = 'https://api.openai.com'
+const DEFAULT_MODEL = 'gpt-image-1.5'
+const LOG_TAG = 'openai-images'
+
+const toErrorMessage = (error: unknown): string =>
+  error instanceof Error ? error.message : String(error)
+
+export const buildOpenAIImagesEndpoint = (baseUrl: string): string => {
+  const normalized = (baseUrl || DEFAULT_BASE_URL).replace(/\/+$/, '')
+  if (/\/images\/generations$/i.test(normalized)) return normalized
+
+  try {
+    const url = new URL(normalized)
+    const path = url.pathname.replace(/\/+$/, '')
+    if (!path) return joinUrl(normalized, '/v1/images/generations')
+  } catch {
+    // Preserve custom fetch-compatible base paths and append the protocol endpoint.
+  }
+  return joinUrl(normalized, '/images/generations')
+}
+
+const trimResponseText = (text: string): string => text.replace(/\s+/g, ' ').trim().slice(0, 500)
+
+const readImagesJsonResponse = async (response: Response): Promise<unknown> => {
+  const contentType = response.headers.get('content-type') || ''
+  const text = await response.text()
+  const preview = trimResponseText(text)
+  if (!response.ok) {
+    throw new Error(
+      `OpenAI Images API failed (${response.status}, ${contentType || 'unknown content-type'}): ${
+        preview || 'empty response'
+      }`
+    )
+  }
+  try {
+    return JSON.parse(text)
+  } catch {
+    throw new Error(
+      `OpenAI Images API returned invalid JSON (${response.status}, ${
+        contentType || 'unknown content-type'
+      }): ${preview || 'empty response'}`
+    )
+  }
+}
+
+const optionalRequestFields = (config: ResolvedImageModelConfig): Record<string, unknown> => {
+  const fields: Record<string, unknown> = {}
+  for (const key of ['quality', 'output_format', 'background', 'moderation']) {
+    const value = readString(config.modelConfig, key)
+    if (value) fields[key] = value
+  }
+  return fields
+}
+
+const resolveOutputMetadata = (
+  config: ResolvedImageModelConfig
+): Pick<ImageGenerationResult, 'mimeType' | 'extension'> | null => {
+  const outputFormat = readString(config.modelConfig, 'output_format').toLowerCase()
+  if (outputFormat === 'jpeg' || outputFormat === 'jpg') {
+    return { mimeType: 'image/jpeg', extension: '.jpg' }
+  }
+  if (outputFormat === 'webp') return { mimeType: 'image/webp', extension: '.webp' }
+  if (outputFormat === 'png') return { mimeType: 'image/png', extension: '.png' }
+  return null
+}
+
+const applyOutputMetadata = (
+  results: ImageGenerationResult[],
+  payload: unknown,
+  metadata: Pick<ImageGenerationResult, 'mimeType' | 'extension'> | null
+): ImageGenerationResult[] => {
+  if (!metadata) return results
+  const data = readRecord(payload).data
+  if (!Array.isArray(data)) return results
+  return results.map((result, index) => {
+    const item = readRecord(data[index])
+    const isBase64Result = Boolean(readString(item, 'b64_json') || readString(item, 'base64'))
+    return isBase64Result ? { ...result, ...metadata } : result
+  })
+}
+
+export const openAiImagesAdapter: ImageGenerationProviderAdapter = {
+  async generate(config, input) {
+    const startedAt = Date.now()
+    const baseUrl = readString(config.modelConfig, 'baseUrl') || DEFAULT_BASE_URL
+    const endpoint =
+      readString(config.modelConfig, 'endpoint') || buildOpenAIImagesEndpoint(baseUrl)
+    const model = readString(config.modelConfig, 'model') || DEFAULT_MODEL
+    const apiKey = readString(config.modelConfig, 'apiKey') || readString(config.modelConfig, 'api_key')
+    if (!model) throw new Error('OpenAI Images API model is required')
+    if (!apiKey) throw new Error('OpenAI Images API key is required')
+
+    const headers = readRecord(config.modelConfig.headers) as Record<string, string>
+    const modelKwargs = readRecord(config.modelConfig.modelKwargs)
+    const count = Math.max(1, input.count)
+
+    log.info(`[images:${LOG_TAG}] generation start`, {
+      configId: config.id,
+      configName: config.name,
+      model,
+      endpoint,
+      count,
+      promptLength: input.prompt.length,
+      modelKwargsKeys: Object.keys(modelKwargs).sort()
+    })
+
+    try {
+      const response = await fetch(endpoint, {
+        method: 'POST',
+        signal: input.signal,
+        headers: {
+          accept: 'application/json',
+          authorization: `Bearer ${apiKey}`,
+          'content-type': 'application/json',
+          ...headers
+        },
+        body: JSON.stringify({
+          ...modelKwargs,
+          ...optionalRequestFields(config),
+          model,
+          prompt: input.prompt,
+          n: count,
+          ...(input.size ? { size: input.size } : {})
+        })
+      })
+      const payload = await readImagesJsonResponse(response)
+      const responseRecord = readRecord(payload)
+      log.info(`[images:${LOG_TAG}] request completed`, {
+        model,
+        status: response.status,
+        responseKeys: Object.keys(responseRecord).sort(),
+        elapsedMs: Date.now() - startedAt
+      })
+      const results = applyOutputMetadata(
+        await collectImageResults(payload, input.signal),
+        payload,
+        resolveOutputMetadata(config)
+      )
+      if (results.length === 0) throw new Error('OpenAI Images API returned no images')
+      log.info(`[images:${LOG_TAG}] generation completed`, {
+        model,
+        resultCount: results.length,
+        elapsedMs: Date.now() - startedAt
+      })
+      return results.slice(0, count)
+    } catch (error) {
+      log.error(`[images:${LOG_TAG}] generation failed`, {
+        model,
+        message: toErrorMessage(error),
+        elapsedMs: Date.now() - startedAt
+      })
+      throw error
+    }
+  }
+}

--- a/src/main/config/image-model-handlers.ts
+++ b/src/main/config/image-model-handlers.ts
@@ -10,6 +10,7 @@ const VALID_IMAGE_PROVIDERS = [
   'agnes',
   'siliconflow',
   'openaiCompatible',
+  'openaiImages',
   'gemini',
   'seedream'
 ] as const

--- a/src/main/image-generation/handlers-history.ts
+++ b/src/main/image-generation/handlers-history.ts
@@ -16,6 +16,7 @@ const VALID_IMAGE_PROVIDERS = [
   'agnes',
   'siliconflow',
   'openaiCompatible',
+  'openaiImages',
   'gemini',
   'seedream'
 ] as const

--- a/src/main/image-generation/handlers.ts
+++ b/src/main/image-generation/handlers.ts
@@ -41,6 +41,7 @@ const VALID_IMAGE_PROVIDERS = [
   'agnes',
   'siliconflow',
   'openaiCompatible',
+  'openaiImages',
   'gemini',
   'seedream'
 ] as const

--- a/src/renderer/src/components/session-detail/ai-panel/imageSizeOptions.ts
+++ b/src/renderer/src/components/session-detail/ai-panel/imageSizeOptions.ts
@@ -34,6 +34,12 @@ const PROVIDER_SIZE_OPTIONS: Record<ImageModelProvider, ImageSizeOption[]> = {
     { value: '1024x1536', label: '2:3 · 1024x1536' },
     { value: 'auto', label: 'auto' }
   ],
+  openaiImages: [
+    { value: '1024x1024', label: '1:1 · 1024x1024' },
+    { value: '1536x1024', label: '3:2 · 1536x1024' },
+    { value: '1024x1536', label: '2:3 · 1024x1536' },
+    { value: 'auto', label: 'auto' }
+  ],
   gemini: [
     { value: '1:1|1K', label: '1:1 · 1K' },
     { value: '16:9|1K', label: '16:9 · 1K' },

--- a/src/renderer/src/components/settings/ImageModelConfigDialog.tsx
+++ b/src/renderer/src/components/settings/ImageModelConfigDialog.tsx
@@ -43,6 +43,10 @@ const PROVIDER_DOCS: Record<ImageModelForm['provider'], { label: string; url: st
     label: 'OpenAI 兼容',
     url: 'https://platform.openai.com/docs/api-reference/chat/create'
   },
+  openaiImages: {
+    label: 'OpenAI Images API',
+    url: 'https://developers.openai.com/api/docs/guides/image-generation'
+  },
   gemini: {
     label: 'Gemini',
     url: 'https://ai.google.dev/gemini-api/docs/image-generation?hl=zh-cn'
@@ -55,6 +59,7 @@ const PROVIDER_HINT_KEYS: Record<ImageModelForm['provider'], Parameters<Settings
   jimeng4: 'settings.imageModelConfigHintJimeng4',
   siliconflow: 'settings.imageModelConfigHintSiliconflow',
   openaiCompatible: 'settings.imageModelConfigHintOpenAICompatible',
+  openaiImages: 'settings.imageModelConfigHintOpenAIImages',
   gemini: 'settings.imageModelConfigHintGemini',
   seedream: 'settings.imageModelConfigHintSeedream'
 }

--- a/src/renderer/src/components/settings/model-settings-utils.ts
+++ b/src/renderer/src/components/settings/model-settings-utils.ts
@@ -9,6 +9,7 @@ export const IMAGE_PROVIDER_OPTIONS: Array<{ value: ImageModelProvider; label: s
   { value: 'seedream', label: 'Seedream' },
   { value: 'siliconflow', label: '硅基流动' },
   { value: 'openaiCompatible', label: 'OpenAI 兼容' },
+  { value: 'openaiImages', label: 'OpenAI Images API' },
   { value: 'gemini', label: 'Gemini' }
 ]
 
@@ -73,6 +74,15 @@ export const createDefaultImageModelConfig = (provider: ImageModelProvider): str
       baseUrl: 'https://api.openai.com',
       apiKey: '',
       model: 'gpt-image-1'
+    })
+  }
+  if (provider === 'openaiImages') {
+    return stringifyJsonObject({
+      baseUrl: 'https://api.openai.com',
+      apiKey: '',
+      model: 'gpt-image-1.5',
+      quality: 'medium',
+      output_format: 'png'
     })
   }
   if (provider === 'gemini') {

--- a/src/renderer/src/i18n/en.ts
+++ b/src/renderer/src/i18n/en.ts
@@ -437,6 +437,8 @@ export const en = {
       'Connect SiliconFlow image models and choose a model name for the style and speed you need. Example: {"model":"Tongyi-MAI/Z-Image-Turbo","apiKey":"..."}',
     imageModelConfigHintOpenAICompatible:
       'Connect a service with OpenAI Chat Completions image capability and generate slide visuals in the same workflow. Example: {"baseUrl":"https://api.openai.com","apiKey":"...","model":"gpt-image-1"}',
+    imageModelConfigHintOpenAIImages:
+      'Use the OpenAI Images API (/v1/images/generations) for slide visuals. Example: {"baseUrl":"https://api.openai.com","apiKey":"...","model":"gpt-image-1.5","quality":"medium","output_format":"png"}',
     imageModelConfigHintGemini:
       'Connect Gemini image generation for illustrations, backgrounds, and visual concepts based on slide content. Uses Google by default, with baseUrl available for a team service endpoint. Example: {"model":"gemini-3.1-flash-image","apiKey":"..."}',
     imageModelConfigHintSeedream:
@@ -475,12 +477,12 @@ export const en = {
       'Image verification only checks basic fields. The real endpoint is verified on first generation to avoid unnecessary cost.',
     modelPlaceholder: 'Example: deepseek-v4-flash',
     imageModelPlaceholder:
-      'Example: Jimeng 3.0 / Jimeng 4.0 / Agnes AI / SiliconFlow / OpenAI compatible / Gemini',
+      'Example: Jimeng 3.0 / Jimeng 4.0 / Agnes AI / SiliconFlow / OpenAI Images API / Gemini',
     imageModelNamePlaceholder: 'Model alias, anything you like',
     baseUrlPlaceholder: 'Example: https://api.deepseek.com',
     imageBaseUrlPlaceholder: 'Leave empty for built-in defaults, or enter a compatible service URL',
     imageBaseUrlHint:
-      'Jimeng 3.0, Jimeng 4.0, Agnes AI, SiliconFlow, OpenAI-compatible image APIs, and Gemini are available.',
+      'Jimeng 3.0, Jimeng 4.0, Agnes AI, SiliconFlow, OpenAI-compatible APIs, OpenAI Images API, and Gemini are available.',
     defaultImageSize: 'Default size',
     defaultImageQuality: 'Default quality',
     defaultImageCount: 'Default count',

--- a/src/renderer/src/i18n/zh.ts
+++ b/src/renderer/src/i18n/zh.ts
@@ -418,6 +418,8 @@ export const zh = {
       '连接硅基流动的图像模型服务，可按模型名称选择不同风格与速度的生成能力。示例：{"model":"Tongyi-MAI/Z-Image-Turbo","apiKey":"..."}',
     imageModelConfigHintOpenAICompatible:
       '连接支持 OpenAI Chat Completions 图片能力的服务，用统一体验生成页面视觉素材。示例：{"baseUrl":"https://api.openai.com","apiKey":"...","model":"gpt-image-1"}',
+    imageModelConfigHintOpenAIImages:
+      '使用 OpenAI Images API（/v1/images/generations）生成页面视觉素材。示例：{"baseUrl":"https://api.openai.com","apiKey":"...","model":"gpt-image-1.5","quality":"medium","output_format":"png"}',
     imageModelConfigHintGemini:
       '连接 Gemini 图像生成能力，用于根据页面内容创建插画、背景和视觉概念图。默认使用 Google 服务，也可填写 baseUrl 接入团队服务地址。示例：{"model":"gemini-3.1-flash-image","apiKey":"..."}',
     imageModelConfigHintSeedream:
@@ -453,11 +455,13 @@ export const zh = {
       '会使用当前 provider 预设下的 model / api_key / base_url 做一次真实连通性校验。（本地ollama随便填写值）',
     imageVerifyHint: '生图验证只检查基础配置，真实接口会在首次文生图时验证，避免产生不必要费用。',
     modelPlaceholder: '例如：deepseek-v4-flash',
-    imageModelPlaceholder: '例如：即梦3.0 / 即梦4.0 / Agnes AI / 硅基流动 / OpenAI 兼容 / Gemini',
+    imageModelPlaceholder:
+      '例如：即梦3.0 / 即梦4.0 / Agnes AI / 硅基流动 / OpenAI Images API / Gemini',
     imageModelNamePlaceholder: '模型别名，随意写',
     baseUrlPlaceholder: '例如：https://api.deepseek.com',
     imageBaseUrlPlaceholder: '留空使用内置默认地址，或填写兼容服务地址',
-    imageBaseUrlHint: '目前开放即梦3.0、即梦4.0、Agnes AI、硅基流动、OpenAI 兼容协议和 Gemini。',
+    imageBaseUrlHint:
+      '目前开放即梦3.0、即梦4.0、Agnes AI、硅基流动、OpenAI 兼容协议、OpenAI Images API 和 Gemini。',
     defaultImageSize: '默认尺寸',
     defaultImageQuality: '默认质量',
     defaultImageCount: '默认张数',

--- a/src/shared/image-generation.ts
+++ b/src/shared/image-generation.ts
@@ -4,6 +4,7 @@ export type ImageModelProvider =
   | 'agnes'
   | 'siliconflow'
   | 'openaiCompatible'
+  | 'openaiImages'
   | 'gemini'
   | 'seedream'
 

--- a/tests/unit/image-generation/openai-images.test.ts
+++ b/tests/unit/image-generation/openai-images.test.ts
@@ -1,0 +1,169 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  resolveImageGenerationProvider,
+  type ResolvedImageModelConfig
+} from '../../../src/main/agent-runtime/provider/image'
+import { buildOpenAIImagesEndpoint } from '../../../src/main/agent-runtime/provider/image/providers/openai-images'
+
+const adapter = resolveImageGenerationProvider('openaiImages')
+const pngBase64 =
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAFgwJ/lK3G1wAAAABJRU5ErkJggg=='
+const pngBytes = Buffer.from(pngBase64, 'base64')
+
+const createConfig = (modelConfig: Record<string, unknown> = {}): ResolvedImageModelConfig => ({
+  id: 'openai-images-config',
+  name: 'OpenAI Images',
+  provider: 'openaiImages',
+  active: true,
+  modelConfig: {
+    apiKey: 'openai-key',
+    model: 'gpt-image-1.5',
+    ...modelConfig
+  }
+})
+
+describe('OpenAI Images API provider', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+  })
+
+  it.each([
+    ['https://api.openai.com', 'https://api.openai.com/v1/images/generations'],
+    ['https://api.openai.com/', 'https://api.openai.com/v1/images/generations'],
+    ['https://api.openai.com/v1', 'https://api.openai.com/v1/images/generations'],
+    ['https://proxy.test/openai/v1', 'https://proxy.test/openai/v1/images/generations'],
+    [
+      'https://proxy.test/openai/v1/images/generations/',
+      'https://proxy.test/openai/v1/images/generations'
+    ]
+  ])('normalizes endpoint %s', (baseUrl, expected) => {
+    expect(buildOpenAIImagesEndpoint(baseUrl)).toBe(expected)
+  })
+
+  it('posts runtime inputs and configured Images API options, then reads base64 results', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ data: [{ b64_json: pngBase64 }] }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' }
+      })
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const results = await adapter.generate(
+      createConfig({
+        baseUrl: 'https://api.openai.com/v1',
+        quality: 'medium',
+        output_format: 'png',
+        background: 'transparent',
+        moderation: 'auto',
+        headers: { 'x-team': 'slides' },
+        modelKwargs: { n: 99, size: 'auto', prompt: 'wrong', user: 'deck-user' }
+      }),
+      { prompt: 'presentation hero', size: '1536x1024', count: 2 }
+    )
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [endpoint, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(endpoint).toBe('https://api.openai.com/v1/images/generations')
+    expect(init.method).toBe('POST')
+    expect(init.headers).toMatchObject({
+      authorization: 'Bearer openai-key',
+      'content-type': 'application/json',
+      'x-team': 'slides'
+    })
+    expect(JSON.parse(String(init.body))).toEqual({
+      n: 2,
+      size: '1536x1024',
+      prompt: 'presentation hero',
+      user: 'deck-user',
+      quality: 'medium',
+      output_format: 'png',
+      background: 'transparent',
+      moderation: 'auto',
+      model: 'gpt-image-1.5'
+    })
+    expect(results).toHaveLength(1)
+    expect(results[0].bytes.length).toBeGreaterThan(0)
+    expect(results[0].mimeType).toBe('image/png')
+  })
+
+  it('uses output_format metadata for base64 results', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ data: [{ b64_json: pngBase64 }] }), { status: 200 })
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const results = await adapter.generate(createConfig({ output_format: 'webp' }), {
+      prompt: 'presentation visual',
+      size: '1024x1024',
+      count: 1
+    })
+
+    expect(results[0]).toMatchObject({ mimeType: 'image/webp', extension: '.webp' })
+  })
+
+  it('uses an explicit endpoint and downloads url results', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ data: [{ url: 'https://assets.test/image.png' }] }), {
+          status: 200
+        })
+      )
+      .mockResolvedValueOnce(
+        new Response(pngBytes, { status: 200, headers: { 'content-type': 'image/png' } })
+      )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const results = await adapter.generate(
+      createConfig({ endpoint: 'https://gateway.test/generate', api_key: 'fallback-key', apiKey: '' }),
+      { prompt: 'visual', size: '1024x1024', count: 1 }
+    )
+
+    expect(fetchMock.mock.calls[0][0]).toBe('https://gateway.test/generate')
+    expect(fetchMock.mock.calls[1][0]).toBe('https://assets.test/image.png')
+    expect(results[0].bytes.equals(pngBytes)).toBe(true)
+  })
+
+  it('reports protocol errors for failed, invalid, and empty responses', async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: { message: 'unsupported size' } }), {
+        status: 400,
+        headers: { 'content-type': 'application/json' }
+      })
+    )
+    await expect(
+      adapter.generate(createConfig(), { prompt: 'visual', size: '1x1', count: 1 })
+    ).rejects.toThrow('OpenAI Images API failed (400')
+
+    fetchMock.mockResolvedValueOnce(new Response('<html>bad gateway</html>', { status: 200 }))
+    await expect(
+      adapter.generate(createConfig(), { prompt: 'visual', size: 'auto', count: 1 })
+    ).rejects.toThrow('OpenAI Images API returned invalid JSON')
+
+    fetchMock.mockResolvedValueOnce(new Response(JSON.stringify({ data: [] }), { status: 200 }))
+    await expect(
+      adapter.generate(createConfig(), { prompt: 'visual', size: 'auto', count: 1 })
+    ).rejects.toThrow('OpenAI Images API returned no images')
+  })
+
+  it('passes the abort signal to the generation request', async () => {
+    const controller = new AbortController()
+    const fetchMock = vi.fn().mockRejectedValue(new DOMException('Aborted', 'AbortError'))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(
+      adapter.generate(createConfig(), {
+        prompt: 'visual',
+        size: 'auto',
+        count: 1,
+        signal: controller.signal
+      })
+    ).rejects.toMatchObject({ name: 'AbortError' })
+    expect((fetchMock.mock.calls[0][1] as RequestInit).signal).toBe(controller.signal)
+  })
+})


### PR DESCRIPTION
## 变更说明

- 新增独立的 `openaiImages` Provider，通过 `POST /v1/images/generations` 调用 OpenAI Images API，同时保留现有 Chat Completions 生图配置与行为
- 在生图模型设置中新增 OpenAI Images API 选项、默认配置、官方文档、中英文帮助文案和支持的图片尺寸
- 支持官方 `b64_json` 响应、兼容服务的 URL 响应、自定义端点、请求头、扩展参数、取消信号和输出格式元数据
- 同步更新生图、历史记录等链路的 Provider 白名单，继续复用现有 Session 资源、添加到画布和设为背景流程

## 默认配置

```json
{
  "baseUrl": "https://api.openai.com",
  "apiKey": "",
  "model": "gpt-image-1.5",
  "quality": "medium",
  "output_format": "png"
}
```

## 验证结果

- `pnpm exec vitest run tests/unit/image-generation/openai-images.test.ts tests/unit/image-generation/seedream.test.ts tests/unit/ipc/image-generation-handlers.test.ts`：18 项测试全部通过
- `pnpm exec tsc --noEmit -p tsconfig.node.json --composite false`：通过
- `pnpm exec tsc --noEmit -p tsconfig.web.json --composite false`：通过
- 已实际运行 `pnpm dev`，Electron 主进程、preload 和 renderer 均成功初始化

## 兼容性说明

- 现有 `openaiCompatible` 生图配置继续使用 Chat Completions，无需迁移
- 本 PR 仅新增 Images API；图片编辑、蒙版以及 Responses API 的生图工具不在本次范围内